### PR TITLE
Devirtualization

### DIFF
--- a/src/Hagar.CodeGenerator/CodeGenerator.cs
+++ b/src/Hagar.CodeGenerator/CodeGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -84,7 +82,7 @@ namespace Hagar.CodeGenerator
             foreach (var type in serializableTypes)
             {
                 // Generate a partial serializer class for each serializable type.
-                members.Add(PartialSerializerGenerator.GenerateSerializer(this.compilation, type));
+                members.Add(SerializerGenerator.GenerateSerializer(this.compilation, type));
             }
 
             var namespaceName = "HagarGeneratedCode." + this.compilation.AssemblyName;

--- a/src/Hagar.CodeGenerator/LibraryTypes.cs
+++ b/src/Hagar.CodeGenerator/LibraryTypes.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace Hagar.CodeGenerator
 {
@@ -8,19 +10,50 @@ namespace Hagar.CodeGenerator
         {
             return new LibraryTypes
             {
-                PartialSerializer = compilation.GetTypeByMetadataName("Hagar.Serializers.IPartialSerializer`1"),
-                ValueSerializer = compilation.GetTypeByMetadataName("Hagar.Serializers.IValueSerializer`1"),
-                FieldCodec = compilation.GetTypeByMetadataName("Hagar.Codecs.IFieldCodec`1"),
-                TypedCodecProvider = compilation.GetTypeByMetadataName("Hagar.Serializers.ITypedCodecProvider"),
-                Writer = compilation.GetTypeByMetadataName("Hagar.Buffers.Writer"),
-                Reader = compilation.GetTypeByMetadataName("Hagar.Buffers.Reader"),
-                SerializerSession = compilation.GetTypeByMetadataName("Hagar.Session.SerializerSession"),
+                PartialSerializer = Type("Hagar.Serializers.IPartialSerializer`1"),
+                ValueSerializer = Type("Hagar.Serializers.IValueSerializer`1"),
+                FieldCodec = Type("Hagar.Codecs.IFieldCodec`1"),
+                TypedCodecProvider = Type("Hagar.Serializers.ITypedCodecProvider"),
+                Writer = Type("Hagar.Buffers.Writer"),
+                Reader = Type("Hagar.Buffers.Reader"),
+                SerializerSession = Type("Hagar.Session.SerializerSession"),
                 Object = compilation.GetSpecialType(SpecialType.System_Object),
-                Type = compilation.GetTypeByMetadataName("System.Type"),
-                SerializerConfiguration = compilation.GetTypeByMetadataName("Hagar.Configuration.SerializerConfiguration"),
-                ConfigurationProvider = compilation.GetTypeByMetadataName("Hagar.Configuration.IConfigurationProvider`1")
+                Type = Type("System.Type"),
+                SerializerConfiguration = Type("Hagar.Configuration.SerializerConfiguration"),
+                ConfigurationProvider = Type("Hagar.Configuration.IConfigurationProvider`1"),
+                StaticCodecs = new List<StaticCodecDescription>()
+                {
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Boolean), Type("Hagar.Codecs.BoolCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Char), Type("Hagar.Codecs.CharCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Byte), Type("Hagar.Codecs.ByteCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_SByte), Type("Hagar.Codecs.SByteCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Int16), Type("Hagar.Codecs.Int16Codec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Int32), Type("Hagar.Codecs.Int32Codec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Int64), Type("Hagar.Codecs.Int64Codec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_UInt16), Type("Hagar.Codecs.UInt16Codec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_UInt32), Type("Hagar.Codecs.UInt32Codec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_UInt64), Type("Hagar.Codecs.UInt64Codec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_String), Type("Hagar.Codecs.StringCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Object), Type("Hagar.Codecs.ObjectCodec")),
+                    new StaticCodecDescription(compilation.CreateArrayTypeSymbol(compilation.GetSpecialType(SpecialType.System_Byte), 1), Type("Hagar.Codecs.ByteArrayCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Single), Type("Hagar.Codecs.FloatCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Double), Type("Hagar.Codecs.DoubleCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Decimal), Type("Hagar.Codecs.DecimalCodec")),
+                    new StaticCodecDescription(compilation.GetSpecialType(SpecialType.System_Decimal), Type("Hagar.Codecs.DecimalCodec")),
+                    new StaticCodecDescription(Type("System.Guid"), Type("Hagar.Codecs.GuidCodec")),
+                    new StaticCodecDescription(Type("System.Type"), Type("Hagar.Codecs.TypeSerializerCodec")),
+                }
             };
+
+            INamedTypeSymbol Type(string metadataName)
+            {
+                var result = compilation.GetTypeByMetadataName(metadataName);
+                if (result == null) throw new InvalidOperationException("Cannot find type with metadata name " + metadataName);
+                return result;
+            }
         }
+
+        public List<StaticCodecDescription> StaticCodecs { get; private set; }
 
         public INamedTypeSymbol TypedCodecProvider { get; private set; }
 

--- a/src/Hagar.CodeGenerator/MetadataGenerator.cs
+++ b/src/Hagar.CodeGenerator/MetadataGenerator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Hagar.CodeGenerator.SyntaxGeneration;
 using Microsoft.CodeAnalysis;
@@ -40,7 +39,7 @@ namespace Hagar.CodeGenerator
             TypeSyntax GetPartialSerializerTypeName(INamedTypeSymbol type)
             {
                 var genericArity = type.TypeParameters.Length;
-                var name = PartialSerializerGenerator.GetSimpleClassName(type);
+                var name = SerializerGenerator.GetSimpleClassName(type);
                 if (genericArity > 0)
                 {
                     name += $"<{new string(',', genericArity - 1)}>";

--- a/src/Hagar.ISerializable/DotNetSerializableCodec.cs
+++ b/src/Hagar.ISerializable/DotNetSerializableCodec.cs
@@ -14,21 +14,16 @@ namespace Hagar.ISerializable
         public static readonly Type CodecType = typeof(DotNetSerializableCodec);
         private static readonly TypeInfo SerializableType = typeof(System.Runtime.Serialization.ISerializable).GetTypeInfo();
         private readonly IFieldCodec<Type> typeCodec;
-        private readonly IUntypedCodecProvider untypedCodecProvider;
         
         private readonly StreamingContext streamingContext = new StreamingContext();
         private readonly ObjectSerializer objectSerializer;
         private readonly ValueTypeSerializerFactory valueTypeSerializerFactory;
 
         public DotNetSerializableCodec(
-            IFieldCodec<Type> typeCodec,
-            IFieldCodec<string> stringCodec,
-            IFieldCodec<object> objectCodec,
-            IUntypedCodecProvider untypedCodecProvider)
+            IFieldCodec<Type> typeCodec)
         {
             this.typeCodec = typeCodec;
-            this.untypedCodecProvider = untypedCodecProvider;
-            var entrySerializer = new SerializationEntryCodec(stringCodec, objectCodec);
+            var entrySerializer = new SerializationEntryCodec();
             var constructorFactory = new SerializationConstructorFactory();
             var serializationCallbacks = new SerializationCallbacksFactory();
             var formatterConverter = new FormatterConverter();
@@ -70,7 +65,7 @@ namespace Hagar.ISerializable
 
         public object ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
-            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference(ref reader, session, field, this.untypedCodecProvider, null);
+            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference(ref reader, session, field, null);
           
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(session);
             var header = reader.ReadFieldHeader(session);

--- a/src/Hagar.ISerializable/SerializationEntryCodec.cs
+++ b/src/Hagar.ISerializable/SerializationEntryCodec.cs
@@ -8,16 +8,8 @@ namespace Hagar.ISerializable
 {
     internal class SerializationEntryCodec : IFieldCodec<SerializationEntrySurrogate>
     {
-        private readonly IFieldCodec<string> stringCodec;
-        private readonly IFieldCodec<object> objectCodec;
         public static readonly Type SerializationEntryType = typeof(SerializationEntrySurrogate);
-
-        public SerializationEntryCodec(IFieldCodec<string> stringCodec, IFieldCodec<object> objectCodec)
-        {
-            this.stringCodec = stringCodec;
-            this.objectCodec = objectCodec;
-        }
-
+        
         public void WriteField(
             ref Writer writer,
             SerializerSession session,
@@ -27,8 +19,8 @@ namespace Hagar.ISerializable
         {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, SerializationEntryType, WireType.TagDelimited);
-            this.stringCodec.WriteField(ref writer, session, 0, typeof(string), value.Name);
-            this.objectCodec.WriteField(ref writer, session, 1, typeof(object), value.Value);
+            StringCodec.WriteField(ref writer, session, 0, typeof(string), value.Name);
+            ObjectCodec.WriteField(ref writer, session, 1, typeof(object), value.Value);
             
             writer.WriteEndObject();
         }
@@ -46,10 +38,10 @@ namespace Hagar.ISerializable
                 switch (fieldId)
                 {
                     case 0:
-                        result.Name = this.stringCodec.ReadValue(ref reader, session, header);
+                        result.Name = StringCodec.ReadValue(ref reader, session, header);
                         break;
                     case 1:
-                        result.Value = this.objectCodec.ReadValue(ref reader, session, header);
+                        result.Value = ObjectCodec.ReadValue(ref reader, session, header);
                         break;
                 }
             }

--- a/src/Hagar.ISerializable/ServiceCollectionExtensions.cs
+++ b/src/Hagar.ISerializable/ServiceCollectionExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Hagar.ISerializable;
+﻿using Hagar.ISerializable;
 using Hagar.Serializers;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Hagar.Json/JsonCodec.cs
+++ b/src/Hagar.Json/JsonCodec.cs
@@ -55,7 +55,7 @@ namespace Hagar.Json
         public object ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             if (field.WireType == WireType.Reference)
-                return ReferenceCodec.ReadReference<object>(ref reader, session, field, this.codecProvider);
+                return ReferenceCodec.ReadReference<object>(ref reader, session, field);
             
             if (field.WireType != WireType.LengthPrefixed) ThrowUnsupportedWireTypeException(field);
             var length = reader.ReadVarUInt32();

--- a/src/Hagar/Codecs/ByteArrayCodec.cs
+++ b/src/Hagar/Codecs/ByteArrayCodec.cs
@@ -9,16 +9,15 @@ namespace Hagar.Codecs
 {
     public class ByteArrayCodec : TypedCodecBase<byte[], ByteArrayCodec>, IFieldCodec<byte[]>
     {
-        private readonly IUntypedCodecProvider codecProvider;
-        public ByteArrayCodec(IUntypedCodecProvider codecProvider)
-        {
-            this.codecProvider = codecProvider;
-        }
-
         byte[] IFieldCodec<byte[]>.ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
+            return ReadValue(ref reader, session, field);
+        }
+
+        public static byte[] ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
             if (field.WireType == WireType.Reference)
-                return ReferenceCodec.ReadReference<byte[]>(ref reader, session, field, this.codecProvider);
+                return ReferenceCodec.ReadReference<byte[]>(ref reader, session, field);
             if (field.WireType != WireType.LengthPrefixed) ThrowUnsupportedWireTypeException(field);
             var length = reader.ReadVarUInt32();
             var result = reader.ReadBytes(length);
@@ -28,10 +27,15 @@ namespace Hagar.Codecs
 
         void IFieldCodec<byte[]>.WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, byte[] value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, byte[] value)
+        {
             if (ReferenceCodec.TryWriteReferenceField(ref writer, session, fieldIdDelta, expectedType, value)) return;
 
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(byte[]), WireType.LengthPrefixed);
-            writer.WriteVarInt((uint)value.Length);
+            writer.WriteVarInt((uint) value.Length);
             writer.Write(value);
         }
 

--- a/src/Hagar/Codecs/ConsumeFieldExtension.cs
+++ b/src/Hagar/Codecs/ConsumeFieldExtension.cs
@@ -1,7 +1,5 @@
-using System;
 using Hagar.Buffers;
 using Hagar.Session;
-using Hagar.Utilities;
 using Hagar.WireProtocol;
 
 namespace Hagar.Codecs

--- a/src/Hagar/Codecs/DictionaryCodec.cs
+++ b/src/Hagar/Codecs/DictionaryCodec.cs
@@ -55,7 +55,7 @@ namespace Hagar.Codecs
         public Dictionary<TKey, TValue> ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             if (field.WireType == WireType.Reference)
-                return ReferenceCodec.ReadReference<Dictionary<TKey, TValue>>(ref reader, session, field, this.codecProvider);
+                return ReferenceCodec.ReadReference<Dictionary<TKey, TValue>>(ref reader, session, field);
             if (field.WireType != WireType.TagDelimited) ThrowUnsupportedWireTypeException(field);
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(session);

--- a/src/Hagar/Codecs/FloatCodec.cs
+++ b/src/Hagar/Codecs/FloatCodec.cs
@@ -14,14 +14,24 @@ namespace Hagar.Codecs
             Type expectedType,
             float value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, float value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(float), WireType.Fixed32);
 
             // TODO: Optimize
-            writer.Write((uint)BitConverter.ToInt32(BitConverter.GetBytes(value), 0));
+            writer.Write((uint) BitConverter.ToInt32(BitConverter.GetBytes(value), 0));
         }
 
         float IFieldCodec<float>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+
+        public static float ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             switch (field.WireType)
@@ -40,8 +50,8 @@ namespace Hagar.Codecs
                 }
 
                 case WireType.Fixed128:
-                // Decimal has a smaller range, but higher precision than float.
-                return (float) reader.ReadDecimal();
+                    // Decimal has a smaller range, but higher precision than float.
+                    return (float) reader.ReadDecimal();
 
                 default:
                     ThrowWireTypeOutOfRange(field.WireType);
@@ -65,14 +75,24 @@ namespace Hagar.Codecs
             Type expectedType,
             double value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, double value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(double), WireType.Fixed64);
 
             // TODO: Optimize
-            writer.Write((ulong)BitConverter.ToInt64(BitConverter.GetBytes(value), 0));
+            writer.Write((ulong) BitConverter.ToInt64(BitConverter.GetBytes(value), 0));
         }
 
         double IFieldCodec<double>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+
+        public static double ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             switch (field.WireType)
@@ -97,6 +117,11 @@ namespace Hagar.Codecs
     {
         void IFieldCodec<decimal>.WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, decimal value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, decimal value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(decimal), WireType.Fixed128);
             var ints = Decimal.GetBits(value);
@@ -104,6 +129,11 @@ namespace Hagar.Codecs
         }
 
         decimal IFieldCodec<decimal>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+
+        public static decimal ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             switch (field.WireType)

--- a/src/Hagar/Codecs/GuidCodec.cs
+++ b/src/Hagar/Codecs/GuidCodec.cs
@@ -9,7 +9,12 @@ namespace Hagar.Codecs
     {
         private const int Width = 16;
 
-        public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Guid value)
+        void IFieldCodec<Guid>.WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Guid value)
+        {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Guid value)
         {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(Guid), WireType.Fixed128);
@@ -24,7 +29,12 @@ namespace Hagar.Codecs
             writer.Write(value.ToByteArray());
         }
 
-        public Guid ReadValue(ref Reader reader, SerializerSession session, Field field)
+        Guid IFieldCodec<Guid>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+
+        public static Guid ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
 #if NETCOREAPP2_1

--- a/src/Hagar/Codecs/IntegerCodec.cs
+++ b/src/Hagar/Codecs/IntegerCodec.cs
@@ -15,12 +15,22 @@ namespace Hagar.Codecs
             Type expectedType,
             bool value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, bool value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(bool), WireType.VarInt);
             writer.WriteVarInt(value ? 1 : 0);
         }
 
         bool IFieldCodec<bool>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static bool ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadUInt8(field.WireType) == 1;
@@ -36,6 +46,11 @@ namespace Hagar.Codecs
             Type expectedType,
             char value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, char value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(char), WireType.VarInt);
             writer.WriteVarInt(value);
@@ -43,8 +58,13 @@ namespace Hagar.Codecs
 
         char IFieldCodec<char>.ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static char ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
             ReferenceCodec.MarkValueField(session);
-            return (char)reader.ReadUInt8(field.WireType);
+            return (char) reader.ReadUInt8(field.WireType);
         }
     }
 
@@ -57,12 +77,22 @@ namespace Hagar.Codecs
             Type expectedType,
             byte value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, byte value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(byte), WireType.VarInt);
             writer.WriteVarInt(value);
         }
 
         byte IFieldCodec<byte>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static byte ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadUInt8(field.WireType);
@@ -78,12 +108,22 @@ namespace Hagar.Codecs
             Type expectedType,
             sbyte value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, sbyte value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(sbyte), WireType.VarInt);
             writer.WriteVarInt(value);
         }
 
         sbyte IFieldCodec<sbyte>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static sbyte ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadInt8(field.WireType);
@@ -93,6 +133,11 @@ namespace Hagar.Codecs
     public class UInt16Codec : TypedCodecBase<ushort, UInt16Codec>, IFieldCodec<ushort>
     {
         ushort IFieldCodec<ushort>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static ushort ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadUInt16(field.WireType);
@@ -104,6 +149,11 @@ namespace Hagar.Codecs
             uint fieldIdDelta,
             Type expectedType,
             ushort value)
+        {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ushort value)
         {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(ushort), WireType.VarInt);
@@ -120,12 +170,22 @@ namespace Hagar.Codecs
             Type expectedType,
             short value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, short value)
+        {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(short), WireType.VarInt);
             writer.WriteVarInt(value);
         }
 
         short IFieldCodec<short>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static short ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadInt16(field.WireType);
@@ -140,6 +200,11 @@ namespace Hagar.Codecs
             uint fieldIdDelta,
             Type expectedType,
             uint value)
+        {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, uint value)
         {
             ReferenceCodec.MarkValueField(session);
             if (value > 1 << 20)
@@ -156,6 +221,11 @@ namespace Hagar.Codecs
 
         uint IFieldCodec<uint>.ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static uint ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadUInt32(field.WireType);
         }
@@ -164,6 +234,16 @@ namespace Hagar.Codecs
     public class Int32Codec : TypedCodecBase<int, Int32Codec>, IFieldCodec<int>
     {
         void IFieldCodec<int>.WriteField(
+            ref Writer writer,
+            SerializerSession session,
+            uint fieldIdDelta,
+            Type expectedType,
+            int value)
+        {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(
             ref Writer writer,
             SerializerSession session,
             uint fieldIdDelta,
@@ -185,6 +265,11 @@ namespace Hagar.Codecs
 
         int IFieldCodec<int>.ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static int ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadInt32(field.WireType);
         }
@@ -194,13 +279,18 @@ namespace Hagar.Codecs
     {
         void IFieldCodec<long>.WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, long value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, long value)
+        {
             ReferenceCodec.MarkValueField(session);
             if (value <= int.MaxValue && value >= int.MinValue)
             {
                 if (value > 1 << 20 || -value > 1 << 20)
                 {
                     writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(long), WireType.Fixed32);
-                    writer.Write((int)value);
+                    writer.Write((int) value);
                 }
                 else
                 {
@@ -222,6 +312,11 @@ namespace Hagar.Codecs
 
         long IFieldCodec<long>.ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static long ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadInt64(field.WireType);
         }
@@ -236,13 +331,18 @@ namespace Hagar.Codecs
             Type expectedType,
             ulong value)
         {
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
+        }
+        
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ulong value)
+        {
             ReferenceCodec.MarkValueField(session);
             if (value <= int.MaxValue)
             {
                 if (value > 1 << 20)
                 {
                     writer.WriteFieldHeader(session, fieldIdDelta, expectedType, typeof(ulong), WireType.Fixed32);
-                    writer.Write((uint)value);
+                    writer.Write((uint) value);
                 }
                 else
                 {
@@ -263,6 +363,11 @@ namespace Hagar.Codecs
         }
 
         ulong IFieldCodec<ulong>.ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            return ReadValue(ref reader, session, field);
+        }
+        
+        public static ulong ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             ReferenceCodec.MarkValueField(session);
             return reader.ReadUInt64(field.WireType);

--- a/src/Hagar/Codecs/KeyValuePairCodec.cs
+++ b/src/Hagar/Codecs/KeyValuePairCodec.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Hagar.Buffers;
+using Hagar.GeneratedCodeHelpers;
 using Hagar.Session;
 using Hagar.WireProtocol;
 
@@ -13,11 +14,11 @@ namespace Hagar.Codecs
 
         public KeyValuePairCodec(IFieldCodec<TKey> keyCodec, IFieldCodec<TValue> valueCodec)
         {
-            this.keyCodec = keyCodec;
-            this.valueCodec = valueCodec;
+            this.keyCodec = HagarGeneratedCodeHelper.UnwrapService(this, keyCodec);
+            this.valueCodec = HagarGeneratedCodeHelper.UnwrapService(this, valueCodec);
         }
 
-        public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, KeyValuePair<TKey, TValue> value)
+        void IFieldCodec<KeyValuePair<TKey, TValue>>.WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, KeyValuePair<TKey, TValue> value)
         {
             ReferenceCodec.MarkValueField(session);
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, value.GetType(), WireType.TagDelimited);
@@ -25,7 +26,6 @@ namespace Hagar.Codecs
             this.keyCodec.WriteField(ref writer, session, 0, typeof(TKey), value.Key);
             this.valueCodec.WriteField(ref writer, session, 1, typeof(TValue), value.Value);
 
-            
             writer.WriteEndObject();
         }
 

--- a/src/Hagar/Codecs/ListCodec.cs
+++ b/src/Hagar/Codecs/ListCodec.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Hagar.Activators;
 using Hagar.Buffers;
-using Hagar.Serializers;
+using Hagar.GeneratedCodeHelpers;
 using Hagar.Session;
 using Hagar.WireProtocol;
 
@@ -15,15 +15,11 @@ namespace Hagar.Codecs
     public class ListCodec<T> : IFieldCodec<List<T>>
     {
         private readonly IFieldCodec<T> fieldCodec;
-        private readonly IFieldCodec<int> intCodec;
-        private readonly IUntypedCodecProvider codecProvider;
         private readonly ListActivator<T> activator;
 
-        public ListCodec(IFieldCodec<T> fieldCodec, IFieldCodec<int> intCodec, IUntypedCodecProvider codecProvider, ListActivator<T> activator)
+        public ListCodec(IFieldCodec<T> fieldCodec, ListActivator<T> activator)
         {
-            this.fieldCodec = fieldCodec;
-            this.intCodec = intCodec;
-            this.codecProvider = codecProvider;
+            this.fieldCodec = HagarGeneratedCodeHelper.UnwrapService(this, fieldCodec);
             this.activator = activator;
         }
 
@@ -32,7 +28,7 @@ namespace Hagar.Codecs
             if (ReferenceCodec.TryWriteReferenceField(ref writer, session, fieldIdDelta, expectedType, value)) return;
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, value.GetType(), WireType.TagDelimited);
 
-            this.intCodec.WriteField(ref writer, session, 0, typeof(int), value.Count);
+            Int32Codec.WriteField(ref writer, session, 0, typeof(int), value.Count);
             var first = true;
             foreach (var element in value)
             {
@@ -47,7 +43,7 @@ namespace Hagar.Codecs
         public List<T> ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             if (field.WireType == WireType.Reference)
-                return ReferenceCodec.ReadReference<List<T>>(ref reader, session, field, this.codecProvider);
+                return ReferenceCodec.ReadReference<List<T>>(ref reader, session, field);
             if (field.WireType != WireType.TagDelimited) ThrowUnsupportedWireTypeException(field);
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(session);
@@ -63,7 +59,7 @@ namespace Hagar.Codecs
                 switch (fieldId)
                 {
                     case 0:
-                        length = this.intCodec.ReadValue(ref reader, session, header);
+                        length = Int32Codec.ReadValue(ref reader, session, header);
                         result = this.activator.Create(length);
                         result.Capacity = length;
                         ReferenceCodec.RecordObject(session, result, placeholderReferenceId);

--- a/src/Hagar/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Hagar/Codecs/MultiDimensionalArrayCodec.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Hagar.Buffers;
+using Hagar.GeneratedCodeHelpers;
 using Hagar.Serializers;
 using Hagar.Session;
 using Hagar.WireProtocol;
@@ -12,15 +13,13 @@ namespace Hagar.Codecs
     /// <typeparam name="T">The array element type.</typeparam>
     internal class MultiDimensionalArrayCodec<T> : IGeneralizedCodec
     {
-        private readonly IUntypedCodecProvider codecProvider;
         private readonly IFieldCodec<int[]> intArrayCodec;
         private readonly IFieldCodec<T> elementCodec;
 
-        public MultiDimensionalArrayCodec(IUntypedCodecProvider codecProvider, IFieldCodec<int[]> intArrayCodec, IFieldCodec<T> elementCodec)
+        public MultiDimensionalArrayCodec(IFieldCodec<int[]> intArrayCodec, IFieldCodec<T> elementCodec)
         {
-            this.codecProvider = codecProvider;
-            this.intArrayCodec = intArrayCodec;
-            this.elementCodec = elementCodec;
+            this.intArrayCodec = HagarGeneratedCodeHelper.UnwrapService(this, intArrayCodec);
+            this.elementCodec = HagarGeneratedCodeHelper.UnwrapService(this, elementCodec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, object value)
@@ -70,7 +69,7 @@ namespace Hagar.Codecs
         public object ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
             if (field.WireType == WireType.Reference)
-                return ReferenceCodec.ReadReference<T[]>(ref reader, session, field, this.codecProvider);
+                return ReferenceCodec.ReadReference<T[]>(ref reader, session, field);
             if (field.WireType != WireType.TagDelimited) ThrowUnsupportedWireTypeException(field);
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(session);

--- a/src/Hagar/Codecs/SkipFieldExtension.cs
+++ b/src/Hagar/Codecs/SkipFieldExtension.cs
@@ -1,7 +1,6 @@
 using System;
 using Hagar.Buffers;
 using Hagar.Session;
-using Hagar.Utilities;
 using Hagar.WireProtocol;
 
 namespace Hagar.Codecs

--- a/src/Hagar/Codecs/TupleCodec.cs
+++ b/src/Hagar/Codecs/TupleCodec.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Hagar.Buffers;
+using Hagar.GeneratedCodeHelpers;
 using Hagar.Session;
 using Hagar.WireProtocol;
 
@@ -11,7 +12,7 @@ namespace Hagar.Codecs
 
         public TupleCodec(IFieldCodec<T> valueCodec)
         {
-            this.valueCodec = valueCodec;
+            this.valueCodec = HagarGeneratedCodeHelper.UnwrapService(this, valueCodec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T> value)
@@ -20,7 +21,6 @@ namespace Hagar.Codecs
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, value.GetType(), WireType.TagDelimited);
 
             this.valueCodec.WriteField(ref writer, session, 0, typeof(T), value.Item1);
-
             
             writer.WriteEndObject();
         }
@@ -64,8 +64,8 @@ namespace Hagar.Codecs
 
         public TupleCodec(IFieldCodec<T1> item1Codec, IFieldCodec<T2> item2Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2> value)
@@ -76,7 +76,6 @@ namespace Hagar.Codecs
             this.item1Codec.WriteField(ref writer, session, 0, typeof(T1), value.Item1);
             this.item2Codec.WriteField(ref writer, session, 1, typeof(T2), value.Item2);
 
-            
             writer.WriteEndObject();
         }
 
@@ -127,9 +126,9 @@ namespace Hagar.Codecs
             IFieldCodec<T2> item2Codec,
             IFieldCodec<T3> item3Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2, T3> value)
@@ -140,7 +139,6 @@ namespace Hagar.Codecs
             this.item1Codec.WriteField(ref writer, session, 0, typeof(T1), value.Item1);
             this.item2Codec.WriteField(ref writer, session, 1, typeof(T2), value.Item2);
             this.item3Codec.WriteField(ref writer, session, 1, typeof(T3), value.Item3);
-
             
             writer.WriteEndObject();
         }
@@ -198,10 +196,10 @@ namespace Hagar.Codecs
             IFieldCodec<T3> item3Codec,
             IFieldCodec<T4> item4Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2, T3, T4> value)
@@ -214,7 +212,6 @@ namespace Hagar.Codecs
             this.item3Codec.WriteField(ref writer, session, 1, typeof(T3), value.Item3);
             this.item4Codec.WriteField(ref writer, session, 1, typeof(T4), value.Item4);
 
-            
             writer.WriteEndObject();
         }
 
@@ -277,11 +274,11 @@ namespace Hagar.Codecs
             IFieldCodec<T4> item4Codec,
             IFieldCodec<T5> item5Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2, T3, T4, T5> value)
@@ -294,7 +291,6 @@ namespace Hagar.Codecs
             this.item3Codec.WriteField(ref writer, session, 1, typeof(T3), value.Item3);
             this.item4Codec.WriteField(ref writer, session, 1, typeof(T4), value.Item4);
             this.item5Codec.WriteField(ref writer, session, 1, typeof(T5), value.Item5);
-
             
             writer.WriteEndObject();
         }
@@ -364,12 +360,12 @@ namespace Hagar.Codecs
             IFieldCodec<T5> item5Codec,
             IFieldCodec<T6> item6Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
-            this.item6Codec = item6Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
+            this.item6Codec = HagarGeneratedCodeHelper.UnwrapService(this, item6Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2, T3, T4, T5, T6> value)
@@ -383,7 +379,6 @@ namespace Hagar.Codecs
             this.item4Codec.WriteField(ref writer, session, 1, typeof(T4), value.Item4);
             this.item5Codec.WriteField(ref writer, session, 1, typeof(T5), value.Item5);
             this.item6Codec.WriteField(ref writer, session, 1, typeof(T6), value.Item6);
-
             
             writer.WriteEndObject();
         }
@@ -459,13 +454,13 @@ namespace Hagar.Codecs
             IFieldCodec<T6> item6Codec,
             IFieldCodec<T7> item7Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
-            this.item6Codec = item6Codec;
-            this.item7Codec = item7Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
+            this.item6Codec = HagarGeneratedCodeHelper.UnwrapService(this, item6Codec);
+            this.item7Codec = HagarGeneratedCodeHelper.UnwrapService(this, item7Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2, T3, T4, T5, T6, T7> value)
@@ -562,14 +557,14 @@ namespace Hagar.Codecs
             IFieldCodec<T7> item7Codec,
             IFieldCodec<T8> item8Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
-            this.item6Codec = item6Codec;
-            this.item7Codec = item7Codec;
-            this.item8Codec = item8Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
+            this.item6Codec = HagarGeneratedCodeHelper.UnwrapService(this, item6Codec);
+            this.item7Codec = HagarGeneratedCodeHelper.UnwrapService(this, item7Codec);
+            this.item8Codec = HagarGeneratedCodeHelper.UnwrapService(this, item8Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Tuple<T1, T2, T3, T4, T5, T6, T7, T8> value)

--- a/src/Hagar/Codecs/TypeSerializerCodec.cs
+++ b/src/Hagar/Codecs/TypeSerializerCodec.cs
@@ -9,18 +9,17 @@ namespace Hagar.Codecs
 {
     public class TypeSerializerCodec : IFieldCodec<Type>
     {
-        private readonly IUntypedCodecProvider codecProvider;
         private static readonly Type SchemaTypeType = typeof(SchemaType);
         private static readonly Type TypeType = typeof(Type);
         private static readonly Type ByteArrayType = typeof(byte[]);
         private static readonly Type UIntType = typeof(uint);
 
-        public TypeSerializerCodec(IUntypedCodecProvider codecProvider)
+        void IFieldCodec<Type>.WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Type value)
         {
-            this.codecProvider = codecProvider;
+            WriteField(ref writer, session, fieldIdDelta, expectedType, value);
         }
 
-        public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Type value)
+        public static void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, Type value)
         {
             if (ReferenceCodec.TryWriteReferenceField(ref writer, session, fieldIdDelta, expectedType, value)) return;
             writer.WriteFieldHeader(session, fieldIdDelta, expectedType, TypeType, WireType.TagDelimited);
@@ -46,13 +45,17 @@ namespace Hagar.Codecs
                 writer.WriteVarInt((uint) id);
             }
 
-            
             writer.WriteEndObject();
         }
 
-        public Type ReadValue(ref Reader reader, SerializerSession session, Field field)
+        Type IFieldCodec<Type>.ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
-            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference<Type>(ref reader, session, field, this.codecProvider);
+            return ReadValue(ref reader, session, field);
+        }
+
+        public static Type ReadValue(ref Reader reader, SerializerSession session, Field field)
+        {
+            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference<Type>(ref reader, session, field);
 
             uint fieldId = 0;
             var schemaType = default(SchemaType);

--- a/src/Hagar/Codecs/UnknownFieldMarker.cs
+++ b/src/Hagar/Codecs/UnknownFieldMarker.cs
@@ -1,4 +1,3 @@
-using System;
 using Hagar.WireProtocol;
 
 namespace Hagar.Codecs

--- a/src/Hagar/Codecs/ValueTupleCodec.cs
+++ b/src/Hagar/Codecs/ValueTupleCodec.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Hagar.Buffers;
+using Hagar.GeneratedCodeHelpers;
 using Hagar.Session;
 using Hagar.Utilities;
 using Hagar.WireProtocol;
@@ -35,7 +36,7 @@ namespace Hagar.Codecs
 
         public ValueTupleCodec(IFieldCodec<T> valueCodec)
         {
-            this.valueCodec = valueCodec;
+            this.valueCodec = HagarGeneratedCodeHelper.UnwrapService(this, valueCodec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T> value)
@@ -85,8 +86,8 @@ namespace Hagar.Codecs
 
         public ValueTupleCodec(IFieldCodec<T1> item1Codec, IFieldCodec<T2> item2Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2> value)
@@ -145,9 +146,9 @@ namespace Hagar.Codecs
             IFieldCodec<T2> item2Codec,
             IFieldCodec<T3> item3Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2, T3> value)
@@ -213,10 +214,10 @@ namespace Hagar.Codecs
             IFieldCodec<T3> item3Codec,
             IFieldCodec<T4> item4Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2, T3, T4> value)
@@ -289,11 +290,11 @@ namespace Hagar.Codecs
             IFieldCodec<T4> item4Codec,
             IFieldCodec<T5> item5Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2, T3, T4, T5> value)
@@ -373,12 +374,12 @@ namespace Hagar.Codecs
             IFieldCodec<T5> item5Codec,
             IFieldCodec<T6> item6Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
-            this.item6Codec = item6Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
+            this.item6Codec = HagarGeneratedCodeHelper.UnwrapService(this, item6Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2, T3, T4, T5, T6> value)
@@ -466,13 +467,13 @@ namespace Hagar.Codecs
             IFieldCodec<T6> item6Codec,
             IFieldCodec<T7> item7Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
-            this.item6Codec = item6Codec;
-            this.item7Codec = item7Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
+            this.item6Codec = HagarGeneratedCodeHelper.UnwrapService(this, item6Codec);
+            this.item7Codec = HagarGeneratedCodeHelper.UnwrapService(this, item7Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2, T3, T4, T5, T6, T7> value)
@@ -567,14 +568,14 @@ namespace Hagar.Codecs
             IFieldCodec<T7> item7Codec,
             IFieldCodec<T8> item8Codec)
         {
-            this.item1Codec = item1Codec;
-            this.item2Codec = item2Codec;
-            this.item3Codec = item3Codec;
-            this.item4Codec = item4Codec;
-            this.item5Codec = item5Codec;
-            this.item6Codec = item6Codec;
-            this.item7Codec = item7Codec;
-            this.item8Codec = item8Codec;
+            this.item1Codec = HagarGeneratedCodeHelper.UnwrapService(this, item1Codec);
+            this.item2Codec = HagarGeneratedCodeHelper.UnwrapService(this, item2Codec);
+            this.item3Codec = HagarGeneratedCodeHelper.UnwrapService(this, item3Codec);
+            this.item4Codec = HagarGeneratedCodeHelper.UnwrapService(this, item4Codec);
+            this.item5Codec = HagarGeneratedCodeHelper.UnwrapService(this, item5Codec);
+            this.item6Codec = HagarGeneratedCodeHelper.UnwrapService(this, item6Codec);
+            this.item7Codec = HagarGeneratedCodeHelper.UnwrapService(this, item7Codec);
+            this.item8Codec = HagarGeneratedCodeHelper.UnwrapService(this, item8Codec);
         }
 
         public void WriteField(ref Writer writer, SerializerSession session, uint fieldIdDelta, Type expectedType, ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> value)

--- a/src/Hagar/Codecs/VoidCodec.cs
+++ b/src/Hagar/Codecs/VoidCodec.cs
@@ -21,7 +21,8 @@ namespace Hagar.Codecs
             {
                 ThrowInvalidWireType(field);
             }
-            return ReferenceCodec.ReadReference<object>(ref reader, session, field, null);
+
+            return ReferenceCodec.ReadReference<object>(ref reader, session, field);
         }
 
         private static void ThrowInvalidWireType(Field field)

--- a/src/Hagar/Exceptions.cs
+++ b/src/Hagar/Exceptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Hagar

--- a/src/Hagar/ObjectModel/TokenStreamParser.cs
+++ b/src/Hagar/ObjectModel/TokenStreamParser.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Hagar.Buffers;
-using Hagar.Codecs;
-using Hagar.Session;
-using Hagar.Utilities;
-using Hagar.WireProtocol;
-
-namespace Hagar.ObjectModel
+﻿namespace Hagar.ObjectModel
 {
     /*
     public static class TokenStreamParser

--- a/src/Hagar/Serializers/AbstractTypeSerializer.cs
+++ b/src/Hagar/Serializers/AbstractTypeSerializer.cs
@@ -44,7 +44,7 @@ namespace Hagar.Serializers
 
         public TField ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
-            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference<TField>(ref reader, session, field, this.codecProvider);
+            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference<TField>(ref reader, session, field);
             var fieldType = field.FieldType;
             if (fieldType == null) ThrowMissingFieldType();
 

--- a/src/Hagar/Serializers/CodecProvider.cs
+++ b/src/Hagar/Serializers/CodecProvider.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using Hagar.Codecs;
 using Hagar.Configuration;
 using Hagar.GeneratedCodeHelpers;
-using Hagar.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 namespace Hagar.Serializers
 {

--- a/src/Hagar/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Hagar/Serializers/ConcreteTypeSerializer.cs
@@ -53,7 +53,7 @@ namespace Hagar.Serializers
 
         public TField ReadValue(ref Reader reader, SerializerSession session, Field field)
         {
-            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference<TField>(ref reader, session, field, this.codecProvider);
+            if (field.WireType == WireType.Reference) return ReferenceCodec.ReadReference<TField>(ref reader, session, field);
             var fieldType = field.FieldType;
             if (fieldType == null || fieldType == CodecFieldType)
             {

--- a/src/Hagar/Session/SerializerSession.cs
+++ b/src/Hagar/Session/SerializerSession.cs
@@ -1,21 +1,23 @@
 using System;
+using Hagar.Serializers;
 using Hagar.TypeSystem;
 
 namespace Hagar.Session
 {
     public sealed class SerializerSession : IDisposable
     {
-        public SerializerSession(TypeCodec typeCodec, WellKnownTypeCollection wellKnownTypes)
+        public SerializerSession(TypeCodec typeCodec, WellKnownTypeCollection wellKnownTypes, CodecProvider codecProvider)
         {
             this.TypeCodec = typeCodec;
             this.WellKnownTypes = wellKnownTypes;
+            this.CodecProvider = codecProvider;
         }
 
         public TypeCodec TypeCodec { get; }
         public WellKnownTypeCollection WellKnownTypes { get; }
         public ReferencedTypeCollection ReferencedTypes { get; } = new ReferencedTypeCollection();
         public ReferencedObjectCollection ReferencedObjects { get; } = new ReferencedObjectCollection();
-
+        public CodecProvider CodecProvider { get; }
         internal Action<SerializerSession> OnDisposed { get; set; }
 
         public void PartialReset()

--- a/src/Hagar/Utilities/PrefixVarintCodec.cs
+++ b/src/Hagar/Utilities/PrefixVarintCodec.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Hagar.Buffers;
+﻿using Hagar.Buffers;
 
 namespace Hagar.Utilities
 {

--- a/src/Hagar/Utilities/VarIntReaderExtensions.cs
+++ b/src/Hagar/Utilities/VarIntReaderExtensions.cs
@@ -6,6 +6,7 @@ namespace Hagar.Utilities
 {
     public static class VarIntReaderExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ReadUInt8(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -21,6 +22,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ReadUInt16(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -36,6 +38,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ReadUInt32(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -51,6 +54,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ReadUInt64(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -66,6 +70,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte ReadInt8(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -81,6 +86,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -96,6 +102,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReadInt32(this ref Reader reader, WireType wireType)
         {
             switch (wireType)
@@ -111,6 +118,7 @@ namespace Hagar.Utilities
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long ReadInt64(this ref Reader reader, WireType wireType)
         {
             switch (wireType)

--- a/src/Hagar/WireProtocol/Tag.cs
+++ b/src/Hagar/WireProtocol/Tag.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace Hagar.WireProtocol
 {
     public struct Tag

--- a/test/Hagar.UnitTests/BuiltInCodecTests.cs
+++ b/test/Hagar.UnitTests/BuiltInCodecTests.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Hagar.Codecs;
-using Hagar.ISerializable;
-using Hagar.Serializers;
 using Hagar.TestKit;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/test/Hagar.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Hagar.UnitTests/GeneratedSerializerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO.Pipelines;
 using Hagar.Buffers;
 using Hagar.Codecs;

--- a/test/TestApp/BaseTypeSerializer.cs
+++ b/test/TestApp/BaseTypeSerializer.cs
@@ -1,5 +1,4 @@
-﻿using Hagar;
-using Hagar.Buffers;
+﻿using Hagar.Buffers;
 using Hagar.Codecs;
 using Hagar.Serializers;
 using Hagar.Session;

--- a/test/TestApp/Models.cs
+++ b/test/TestApp/Models.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Hagar;
-using Hagar.Codecs;
 
 namespace MyPocos
 {

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -9,7 +9,6 @@ using Hagar.Buffers;
 using Hagar.Codecs;
 using Hagar.ISerializable;
 using Hagar.Json;
-using Hagar.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MyPocos;
 using Newtonsoft.Json;


### PR DESCRIPTION
1. Unwrap potentially wrapped codecs in ValueTuple/Tuple/Array/ISerializable/etc codecs
2. In generated code, directly call static codecs when available, rather than always using injected codecs