### PR TITLE
Add SpanJson in Comparison Benchmark

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.3" />
     <PackageReference Include="protobuf-net" Version="2.3.14" />
+    <PackageReference Include="SpanJson" Version="1.2.4" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator" Version="2.0.3" />
     <PackageReference Include="ZeroFormatter" Version="1.6.4" />

--- a/test/Benchmarks/Comparison/DeserializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/DeserializeBenchmark.cs
@@ -32,6 +32,8 @@ namespace Benchmarks.Comparison
 
         private static readonly string NewtonsoftJsonInput = JsonConvert.SerializeObject(IntClass.Create());
 
+        private static readonly byte[] SpanJsonInput = SpanJson.JsonSerializer.Generic.Utf8.Serialize(IntClass.Create());
+
         private static readonly Hyperion.Serializer HyperionSerializer = new Hyperion.Serializer(new SerializerOptions(knownTypes: new[] {typeof(IntClass) }));
         private static readonly MemoryStream HyperionInput;
 
@@ -149,6 +151,12 @@ namespace Benchmarks.Comparison
         public int NewtonsoftJson()
         {
             return SumResult(JsonConvert.DeserializeObject<IntClass>(NewtonsoftJsonInput));
+        }
+
+        [Benchmark(Description = "SpanJson")]
+        public int SpanJsonUtf8()
+        {
+            return SumResult(SpanJson.JsonSerializer.Generic.Utf8.Deserialize<IntClass>(SpanJsonInput));
         }
     }
 }

--- a/test/Benchmarks/Comparison/SerializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/SerializeBenchmark.cs
@@ -111,5 +111,12 @@ namespace Benchmarks.Comparison
             var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(Input));
             return bytes.Length;
         }
+
+        [Benchmark(Description = "SpanJson")]
+        public int SpanJsonUtf8()
+        {
+            var bytes = SpanJson.JsonSerializer.Generic.Utf8.Serialize(Input);
+            return bytes.Length;
+        }
     }
 }

--- a/test/Benchmarks/Comparison/StructDeserializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/StructDeserializeBenchmark.cs
@@ -27,6 +27,8 @@ namespace Benchmarks.Comparison
         private static readonly MemoryStream ProtoInput;
         private static readonly string NewtonsoftJsonInput = JsonConvert.SerializeObject(IntStruct.Create());
 
+        private static readonly byte[] SpanJsonInput = SpanJson.JsonSerializer.Generic.Utf8.Serialize(IntStruct.Create());
+
         private static readonly byte[] MsgPackInput = MessagePack.MessagePackSerializer.Serialize(IntStruct.Create());
         private static readonly byte[] ZeroFormatterInput = ZeroFormatterSerializer.Serialize(IntStruct.Create());
         private static readonly Hyperion.Serializer HyperionSerializer = new Hyperion.Serializer(new SerializerOptions(knownTypes: new[] {typeof(IntStruct)}));
@@ -131,6 +133,12 @@ namespace Benchmarks.Comparison
         public int NewtonsoftJson()
         {
             return SumResult(JsonConvert.DeserializeObject<IntStruct>(NewtonsoftJsonInput));
+        }
+
+        [Benchmark(Description = "SpanJson")]
+        public int SpanJsonUtf8()
+        {
+            return SumResult(SpanJson.JsonSerializer.Generic.Utf8.Deserialize<IntStruct>(SpanJsonInput));
         }
     }
 }

--- a/test/Benchmarks/Comparison/StructSerializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/StructSerializeBenchmark.cs
@@ -110,5 +110,12 @@ namespace Benchmarks.Comparison
             var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(Input));
             return bytes.Length;
         }
+
+        [Benchmark(Description = "SpanJson")]
+        public int SpanJsonUtf8()
+        {
+            var bytes = SpanJson.JsonSerializer.Generic.Utf8.Serialize(Input);
+            return bytes.Length;
+        }
     }
 }


### PR DESCRIPTION
This PR adds SpanJson for the Comparison Benchmarks.
I had to use the Benchmark Description in the Attribute, otherwise I'd run into namespace problems.
As for values:
***SerializeBenchmark***

``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.191 (1803/April2018Update/Redstone4)
Intel Xeon CPU E5-1620 0 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.302
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|            Method |        Mean |      Error |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated | Payload |
|------------------ |------------:|-----------:|-----------:|-------:|---------:|-------:|----------:|--------:|
|             Hagar |   161.56 ns |  0.1470 ns |  0.1303 ns |   1.00 |     0.00 |      - |       0 B |    20 B |
|           Orleans | 2,199.24 ns | 27.9259 ns | 26.1219 ns |  13.61 |     0.16 | 0.1907 |    1016 B |    77 B |
| MessagePackCSharp |    98.58 ns |  0.4990 ns |  0.4424 ns |   0.61 |     0.00 | 0.0075 |      40 B |    10 B |
|       ProtobufNet |   653.56 ns |  4.3703 ns |  3.8742 ns |   4.05 |     0.02 | 0.0391 |     208 B |    18 B |
|          Hyperion |   214.15 ns |  0.5509 ns |  0.5153 ns |   1.33 |     0.00 | 0.0181 |      96 B |    39 B |
|    NewtonsoftJson | 2,346.41 ns | 27.2909 ns | 22.7891 ns |  14.52 |     0.14 | 0.3853 |    2032 B |   154 B |
|          SpanJson |   248.50 ns |  2.5762 ns |  2.0113 ns |   1.54 |     0.01 | 0.0348 |     184 B |   154 B |


***DeserializeBenchmark***
``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.191 (1803/April2018Update/Redstone4)
Intel Xeon CPU E5-1620 0 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.302
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|            Method |       Mean |      Error |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|------------------ |-----------:|-----------:|-----------:|-------:|---------:|-------:|----------:|
|             Hagar |   734.4 ns |  1.8816 ns |  1.6679 ns |   1.00 |     0.00 | 0.0105 |      56 B |
|           Orleans | 1,185.6 ns | 11.2158 ns |  9.9425 ns |   1.61 |     0.01 | 0.0839 |     448 B |
| MessagePackCSharp |   102.0 ns |  0.1494 ns |  0.1397 ns |   0.14 |     0.00 | 0.0106 |      56 B |
|       ProtobufNet | 1,080.5 ns |  1.8684 ns |  1.6563 ns |   1.47 |     0.00 | 0.0210 |     112 B |
|          Hyperion |   239.9 ns |  0.6374 ns |  0.5962 ns |   0.33 |     0.00 | 0.0300 |     160 B |
|     ZeroFormatter |   358.5 ns |  2.5551 ns |  2.2650 ns |   0.49 |     0.00 | 0.0410 |     216 B |
|    NewtonsoftJson | 4,328.2 ns | 19.4180 ns | 18.1636 ns |   5.89 |     0.03 | 0.5417 |    2856 B |
|          SpanJson |   419.5 ns |  0.5611 ns |  0.5248 ns |   0.57 |     0.00 | 0.0105 |      56 B |

***StructSerializeBenchmark***

``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.191 (1803/April2018Update/Redstone4)
Intel Xeon CPU E5-1620 0 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.302
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|            Method |        Mean |      Error |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated | Payload |
|------------------ |------------:|-----------:|-----------:|-------:|---------:|-------:|----------:|--------:|
|             Hagar |   148.47 ns |  0.7338 ns |  0.6505 ns |   1.00 |     0.00 |      - |       0 B |    20 B |
|           Orleans | 2,209.79 ns | 17.7479 ns | 16.6014 ns |  14.88 |     0.13 | 0.2022 |    1072 B |    78 B |
| MessagePackCSharp |    95.00 ns |  2.2668 ns |  2.0095 ns |   0.64 |     0.01 | 0.0075 |      40 B |    10 B |
|       ProtobufNet |   477.57 ns |  8.2819 ns |  7.7469 ns |   3.22 |     0.05 | 0.0496 |     264 B |     0 B |
|          Hyperion |   226.58 ns |  1.2373 ns |  1.1574 ns |   1.53 |     0.01 | 0.0288 |     152 B |    39 B |
|     ZeroFormatter |    97.38 ns |  0.6295 ns |  0.5889 ns |   0.66 |     0.00 | 0.0122 |      64 B |    36 B |
|    NewtonsoftJson | 2,148.08 ns | 15.8546 ns | 14.8304 ns |  14.47 |     0.11 | 0.3738 |    1968 B |   145 B |
|          SpanJson |   213.35 ns |  0.8179 ns |  0.7650 ns |   1.44 |     0.01 | 0.0334 |     176 B |   145 B |

***StructDeserializeBenchmark***
``` ini

BenchmarkDotNet=v0.11.0, OS=Windows 10.0.17134.191 (1803/April2018Update/Redstone4)
Intel Xeon CPU E5-1620 0 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.302
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|            Method |        Mean |      Error |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|------------------ |------------:|-----------:|-----------:|-------:|---------:|-------:|----------:|
|             Hagar |   642.79 ns |  0.5859 ns |  0.4892 ns |   1.00 |     0.00 |      - |       0 B |
|           Orleans | 1,267.01 ns | 24.7129 ns | 24.2714 ns |   1.97 |     0.04 | 0.0839 |     448 B |
| MessagePackCSharp |    97.55 ns |  2.5528 ns |  2.6216 ns |   0.15 |     0.00 |      - |       0 B |
|       ProtobufNet | 1,109.37 ns | 16.4617 ns | 13.7462 ns |   1.73 |     0.02 | 0.0305 |     168 B |
|          Hyperion |   183.43 ns |  0.8550 ns |  0.6675 ns |   0.29 |     0.00 | 0.0303 |     160 B |
|     ZeroFormatter |    68.77 ns |  0.0955 ns |  0.0894 ns |   0.11 |     0.00 |      - |       0 B |
|    NewtonsoftJson | 8,174.07 ns | 58.3415 ns | 51.7182 ns |  12.72 |     0.08 | 0.6409 |    3432 B |
|          SpanJson |   392.42 ns |  0.9242 ns |  0.7718 ns |   0.61 |     0.00 |      - |       0 B |
