### PR TITLE
Improve deserialization performance by using a compiled lambda expression to create new instances

### DIFF
--- a/src/Hagar/Activators/DefaultActivator.cs
+++ b/src/Hagar/Activators/DefaultActivator.cs
@@ -1,22 +1,25 @@
+using System;
+using System.Linq.Expressions;
+
 namespace Hagar.Activators
 {
     public class DefaultActivator<T> : IActivator<T>
     {
-        private static readonly bool HasDefaultConstructor;
+        private static readonly Func<T> DefaultConstructorFunction;
 
         static DefaultActivator()
         {
             foreach (var ctor in typeof(T).GetConstructors())
             {
-                if (ctor.GetParameters().Length == 0) HasDefaultConstructor = true;
+                if (ctor.GetParameters().Length != 0) continue;
+
+                var newExpression = Expression.New(ctor);
+                DefaultConstructorFunction = Expression.Lambda<Func<T>>(newExpression).Compile();
+                break;
             }
         }
 
-        public T Create()
-        {
-            if (HasDefaultConstructor) return System.Activator.CreateInstance<T>();
-            return CreateUnformatted();
-        }
+        public T Create() => DefaultConstructorFunction != null ? DefaultConstructorFunction() : CreateUnformatted();
 
         private static T CreateUnformatted() => (T)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(typeof(T));
     }


### PR DESCRIPTION
Hi @ReubenBond. I came across your tweet today and thought I would take a look at the progress on this exciting project.

While looking through  the code I noticed the use of `Activator.CreateInstance<T>` in the `DefaultActivator<T>` class. This uses reflection under the hood, and while it does have a caching mechanism, it still does more work than a direct call to `new`. I tested replacing it with a compiled lambda expression that invokes the default constructor directly. Running the `DeserializeBenchmark` indicates this gives a nice bump to performance for very little effort.

Host and machine specs:

``` ini
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
```

Before (`Activator.CreateInstance<T>`):

```
| Method |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|------:|-------:|------:|------:|----------:|
|  Hagar | 326.3 ns | 2.456 ns | 2.177 ns |  1.00 | 0.0067 |     - |     - |      56 B |
```

After (`Expression.New`):

```
| Method |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|---------:|---------:|------:|-------:|------:|------:|----------:|
|  Hagar | 292.2 ns | 2.403 ns | 2.007 ns |  1.00 | 0.0067 |     - |     - |      56 B |
```

Comparison benchmark (with above change in place):

```
|            Method |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|             Hagar |   288.60 ns | 2.1556 ns | 2.0163 ns |  1.00 |    0.00 | 0.0067 |     - |     - |      56 B |
|           Orleans |   657.07 ns | 4.3444 ns | 3.6278 ns |  2.28 |    0.02 | 0.0820 |     - |     - |     688 B |
| MessagePackCSharp |    55.43 ns | 1.0527 ns | 0.8790 ns |  0.19 |    0.00 | 0.0067 |     - |     - |      56 B |
|       ProtobufNet |   532.56 ns | 1.9129 ns | 1.7893 ns |  1.85 |    0.01 | 0.0134 |     - |     - |     112 B |
|          Hyperion |   136.96 ns | 0.6992 ns | 0.5838 ns |  0.47 |    0.00 | 0.0191 |     - |     - |     160 B |
|    NewtonsoftJson | 2,402.01 ns | 6.8730 ns | 6.4290 ns |  8.32 |    0.06 | 0.3395 |     - |     - |    2856 B |
|          SpanJson |   241.29 ns | 1.2691 ns | 1.1871 ns |  0.84 |    0.01 | 0.0067 |     - |     - |      56 B |
```