### PR TITLE
Reduce allocs in TypeCodec

### DIFF
--- a/src/Hagar/TypeSystem/JenkinsHash.cs
+++ b/src/Hagar/TypeSystem/JenkinsHash.cs
@@ -1,4 +1,6 @@
-﻿namespace Hagar.TypeSystem
+using System;
+
+namespace Hagar.TypeSystem
 {
     // TODO: Profile and possibly pick a faster/more suitable hashing algorithm.
 
@@ -24,7 +26,7 @@
         }
 
         // This is the reference implementation of the Jenkins hash.
-        public static uint ComputeHash(byte[] data)
+        public static uint ComputeHash(ReadOnlySpan<byte> data)
         {
             int len = data.Length;
             uint a = 0x9e3779b9;


### PR DESCRIPTION
We can avoid allocations for named types by directly inspecting the deserialization buffers, but it requires some reworking.