### PR TITLE
Add user-friendly Serializer and Serializer<T> types

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -92,7 +92,7 @@ public interface IInvokableWithResult
     void SerializeResult(ref Writer<TBuffer> writer) where TBuffer : IOutputStream;
 
     // Called on receiver side after call returns from (remote) target.
-    void DeserializeResult(ref Reader reader);
+    void DeserializeResult(ref Reader<TInput> reader);
 }
 
 [Serializable]
@@ -133,7 +133,7 @@ public struct MyInterface_MyMethod_Closure<TTarget, TMethodArg1, TMethodParam2> 
     public void SerializeResult(ref Writer<TBuffer> writer) where TBuffer : IOutputStream;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void DeserializeResult(ref Reader reader);
+    public void DeserializeResult(ref Reader<TInput> reader);
 
     void SetTarget<T>()
 

--- a/TestRpc/IO/ConnectionHandler.cs
+++ b/TestRpc/IO/ConnectionHandler.cs
@@ -88,7 +88,7 @@ namespace TestRpc.IO
 
             Message ReadMessage(ReadOnlySequence<byte> payload, SerializerSession session, out SequencePosition consumedTo)
             {
-                var reader = new Reader(payload, session);
+                var reader = Reader.Create(payload, session);
                 var result = _messageSerializer.Deserialize(ref reader);
                 consumedTo = payload.GetPosition(reader.Position);
                 return result;

--- a/TestRpc/IO/ConnectionHandler.cs
+++ b/TestRpc/IO/ConnectionHandler.cs
@@ -125,7 +125,7 @@ namespace TestRpc.IO
             void WriteMessage(Message message, SerializerSession session)
             {
                 var writer = Writer.Create(_connection.Output, session);
-                _messageSerializer.Serialize(ref writer, message);
+                _messageSerializer.Serialize(message, ref writer);
             }
         }
     }

--- a/TestRpc/IO/ConnectionHandler.cs
+++ b/TestRpc/IO/ConnectionHandler.cs
@@ -124,7 +124,7 @@ namespace TestRpc.IO
 
             void WriteMessage(Message message, SerializerSession session)
             {
-                var writer = new Writer<PipeWriter>(_connection.Output, session);
+                var writer = Writer.Create(_connection.Output, session);
                 _messageSerializer.Serialize(ref writer, message);
             }
         }

--- a/TestRpc/TestRpc.csproj
+++ b/TestRpc/TestRpc.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <!--<HagarCodeGenWaitForDebugger>true</HagarCodeGenWaitForDebugger>-->
   </PropertyGroup>

--- a/src/Hagar.CodeGenerator/LibraryTypes.cs
+++ b/src/Hagar.CodeGenerator/LibraryTypes.cs
@@ -21,7 +21,7 @@ namespace Hagar.CodeGenerator
                 TypedCodecProvider = Type("Hagar.Serializers.ITypedCodecProvider"),
                 Writer = Type("Hagar.Buffers.Writer`1"),
                 IBufferWriter = Type("System.Buffers.IBufferWriter`1"),
-                Reader = Type("Hagar.Buffers.Reader"),
+                Reader = Type("Hagar.Buffers.Reader`1"),
                 SerializerSession = Type("Hagar.Session.SerializerSession"),
                 Request = Type("Hagar.Invocation.Request"),
                 Request_1 = Type("Hagar.Invocation.Request`1"),

--- a/src/Hagar.CodeGenerator/SerializerGenerator.cs
+++ b/src/Hagar.CodeGenerator/SerializerGenerator.cs
@@ -438,9 +438,10 @@ namespace Hagar.CodeGenerator
 
             body.Add(WhileStatement(LiteralExpression(SyntaxKind.TrueLiteralExpression), Block(GetDeserializerLoopBody())));
 
+            var genericParam = ParseTypeName("TInput");
             var parameters = new[]
             {
-                Parameter(readerParam.Identifier).WithType(libraryTypes.Reader.ToTypeSyntax()).WithModifiers(TokenList(Token(SyntaxKind.RefKeyword))),
+                Parameter(readerParam.Identifier).WithType(libraryTypes.Reader.ToTypeSyntax(genericParam)).WithModifiers(TokenList(Token(SyntaxKind.RefKeyword))),
                 Parameter(instanceParam.Identifier).WithType(type.TypeSyntax)
             };
 
@@ -450,6 +451,7 @@ namespace Hagar.CodeGenerator
             }
 
             return MethodDeclaration(returnType, DeserializeMethodName)
+                .AddTypeParameterListParameters(TypeParameter("TInput"))
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddParameterListParameters(parameters)
                 .AddBodyStatements(body.ToArray());

--- a/src/Hagar.ISerializable/DotNetSerializableCodec.cs
+++ b/src/Hagar.ISerializable/DotNetSerializableCodec.cs
@@ -70,11 +70,11 @@ namespace Hagar.ISerializable
         }
 
         [SecurityCritical]
-        public object ReadValue(ref Reader reader, Field field)
+        public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<object>(ref reader, field);
+                return ReferenceCodec.ReadReference<object, TInput>(ref reader, field);
             }
 
             var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);

--- a/src/Hagar.ISerializable/ISerializableSerializer.cs
+++ b/src/Hagar.ISerializable/ISerializableSerializer.cs
@@ -7,6 +7,6 @@ namespace Hagar.ISerializable
     internal interface ISerializableSerializer
     {
         void WriteValue<TBufferWriter>(ref Writer<TBufferWriter> writer, object value) where TBufferWriter : IBufferWriter<byte>;
-        object ReadValue(ref Reader reader, Type type, uint placeholderReferenceId);
+        object ReadValue<TInput>(ref Reader<TInput> reader, Type type, uint placeholderReferenceId);
     }
 }

--- a/src/Hagar.ISerializable/ObjectSerializer.cs
+++ b/src/Hagar.ISerializable/ObjectSerializer.cs
@@ -61,7 +61,7 @@ namespace Hagar.ISerializable
         }
 
         [SecurityCritical]
-        public object ReadValue(ref Reader reader, Type type, uint placeholderReferenceId)
+        public object ReadValue<TInput>(ref Reader<TInput> reader, Type type, uint placeholderReferenceId)
         {
             var callbacks = _serializationCallbacks.GetReferenceTypeCallbacks(type);
 

--- a/src/Hagar.ISerializable/SerializationEntryCodec.cs
+++ b/src/Hagar.ISerializable/SerializationEntryCodec.cs
@@ -26,7 +26,7 @@ namespace Hagar.ISerializable
         }
 
         [SecurityCritical]
-        public SerializationEntrySurrogate ReadValue(ref Reader reader, Field field)
+        public SerializationEntrySurrogate ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             var result = new SerializationEntrySurrogate();

--- a/src/Hagar.ISerializable/ValueTypeSerializer.cs
+++ b/src/Hagar.ISerializable/ValueTypeSerializer.cs
@@ -64,7 +64,7 @@ namespace Hagar.ISerializable
         }
 
         [SecurityCritical]
-        object ISerializableSerializer.ReadValue(ref Reader reader, Type type, uint placeholderReferenceId)
+        object ISerializableSerializer.ReadValue<TInput>(ref Reader<TInput> reader, Type type, uint placeholderReferenceId)
         {
             var info = new SerializationInfo(Type, _formatterConverter);
             T result = default;

--- a/src/Hagar.NewtonsoftJson/NewtonsoftJsonCodec.cs
+++ b/src/Hagar.NewtonsoftJson/NewtonsoftJsonCodec.cs
@@ -47,11 +47,11 @@ namespace Hagar.Json
             writer.Write(bytes);
         }
 
-        object IFieldCodec<object>.ReadValue(ref Reader reader, Field field)
+        object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<object>(ref reader, field);
+                return ReferenceCodec.ReadReference<object, TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.LengthPrefixed)

--- a/src/Hagar.TestKit/BufferTestHelper.cs
+++ b/src/Hagar.TestKit/BufferTestHelper.cs
@@ -41,7 +41,7 @@ namespace Hagar.TestKit
             public IOutputBuffer Serialize(TValue input)
             {
                 using var session = _sessionPool.GetSession();
-                var writer = new Writer<TBufferWriter>(CreateBufferWriter(), session);
+                var writer = Writer.Create(CreateBufferWriter(), session);
                 _serializer.Serialize(ref writer, input);
                 return writer.Output;
             }

--- a/src/Hagar.TestKit/BufferTestHelper.cs
+++ b/src/Hagar.TestKit/BufferTestHelper.cs
@@ -49,7 +49,7 @@ namespace Hagar.TestKit
             public void Deserialize(ReadOnlySequence<byte> buffer, out TValue output)
             {
                 using var session = _sessionPool.GetSession();
-                var reader = new Reader(buffer, session);
+                var reader = Reader.Create(buffer, session);
                 output = _serializer.Deserialize(ref reader);
             }
         }

--- a/src/Hagar.TestKit/BufferTestHelper.cs
+++ b/src/Hagar.TestKit/BufferTestHelper.cs
@@ -42,7 +42,7 @@ namespace Hagar.TestKit
             {
                 using var session = _sessionPool.GetSession();
                 var writer = Writer.Create(CreateBufferWriter(), session);
-                _serializer.Serialize(ref writer, input);
+                _serializer.Serialize(input, ref writer);
                 return writer.Output;
             }
 

--- a/src/Hagar.TestKit/FieldCodecTester.cs
+++ b/src/Hagar.TestKit/FieldCodecTester.cs
@@ -64,7 +64,7 @@ namespace Hagar.TestKit
             pipe.Writer.Complete();
 
             _ = pipe.Reader.TryRead(out var readResult);
-            var reader = new Reader(readResult.Buffer, _sessionPool.GetSession());
+            var reader = Reader.Create(readResult.Buffer, _sessionPool.GetSession());
 
             var previousPos = reader.Position;
             Assert.Equal(0, previousPos);
@@ -97,7 +97,7 @@ namespace Hagar.TestKit
                 var writer = new Writer<TestMultiSegmentBufferWriter>(buffer, _sessionPool.GetSession());
                 serializer.Serialize(ref writer, original);
 
-                var reader = new Reader(buffer.GetReadOnlySequence(0), _sessionPool.GetSession());
+                var reader = Reader.Create(buffer.GetReadOnlySequence(0), _sessionPool.GetSession());
                 var deserialized = serializer.Deserialize(ref reader);
 
                 Assert.True(Equals(original, deserialized), $"Deserialized value \"{deserialized}\" must equal original value \"{original}\"");
@@ -116,7 +116,7 @@ namespace Hagar.TestKit
                 var writer = new Writer<TestSingleSegmentBufferWriter>(buffer, _sessionPool.GetSession());
                 serializer.Serialize(ref writer, original);
 
-                var reader = new Reader(buffer.GetReadOnlySequence(0), _sessionPool.GetSession());
+                var reader = Reader.Create(buffer.GetReadOnlySequence(0), _sessionPool.GetSession());
                 var deserializedObject = serializer.Deserialize(ref reader);
                 if (original != null)
                 {
@@ -180,7 +180,7 @@ namespace Hagar.TestKit
             _ = pipe.Reader.TryRead(out var readResult);
 
             {
-                var reader = new Reader(readResult.Buffer, _sessionPool.GetSession());
+                var reader = Reader.Create(readResult.Buffer, _sessionPool.GetSession());
                 var readField = reader.ReadFieldHeader();
                 reader.SkipField(readField);
                 Assert.Equal(expectedLength, reader.Position);
@@ -188,7 +188,7 @@ namespace Hagar.TestKit
 
             {
                 var codec = new SkipFieldCodec();
-                var reader = new Reader(readResult.Buffer, _sessionPool.GetSession());
+                var reader = Reader.Create(readResult.Buffer, _sessionPool.GetSession());
                 var readField = reader.ReadFieldHeader();
                 var shouldBeNull = codec.ReadValue(ref reader, readField);
                 Assert.Null(shouldBeNull);
@@ -210,7 +210,7 @@ namespace Hagar.TestKit
             pipe.Writer.Complete();
 
             _ = pipe.Reader.TryRead(out var readResult);
-            var reader = new Reader(readResult.Buffer, _sessionPool.GetSession());
+            var reader = Reader.Create(readResult.Buffer, _sessionPool.GetSession());
             var readerCodec = CreateCodec();
             var readField = reader.ReadFieldHeader();
             var deserialized = readerCodec.ReadValue(ref reader, readField);

--- a/src/Hagar.TestKit/FieldCodecTester.cs
+++ b/src/Hagar.TestKit/FieldCodecTester.cs
@@ -47,7 +47,7 @@ namespace Hagar.TestKit
         public void CorrectlyAdvancesReferenceCounter()
         {
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, _sessionPool.GetSession());
+            var writer = Writer.Create(pipe.Writer, _sessionPool.GetSession());
             var writerCodec = CreateCodec();
             var beforeReference = writer.Session.ReferencedObjects.CurrentReferenceId;
 
@@ -94,7 +94,7 @@ namespace Hagar.TestKit
             {
                 var buffer = new TestMultiSegmentBufferWriter(1024);
 
-                var writer = new Writer<TestMultiSegmentBufferWriter>(buffer, _sessionPool.GetSession());
+                var writer = Writer.Create(buffer, _sessionPool.GetSession());
                 serializer.Serialize(ref writer, original);
 
                 var reader = Reader.Create(buffer.GetReadOnlySequence(0), _sessionPool.GetSession());
@@ -113,7 +113,7 @@ namespace Hagar.TestKit
             {
                 var buffer = new TestSingleSegmentBufferWriter(new byte[10240]);
 
-                var writer = new Writer<TestSingleSegmentBufferWriter>(buffer, _sessionPool.GetSession());
+                var writer = Writer.Create(buffer, _sessionPool.GetSession());
                 serializer.Serialize(ref writer, original);
 
                 var reader = Reader.Create(buffer.GetReadOnlySequence(0), _sessionPool.GetSession());
@@ -169,7 +169,7 @@ namespace Hagar.TestKit
         private void CanBeSkipped(TValue original)
         {
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, _sessionPool.GetSession());
+            var writer = Writer.Create(pipe.Writer, _sessionPool.GetSession());
             var writerCodec = CreateCodec();
             writerCodec.WriteField(ref writer, 0, typeof(TValue), original);
             var expectedLength = writer.Position;
@@ -202,7 +202,7 @@ namespace Hagar.TestKit
         private void TestRoundTrippedValue(TValue original)
         {
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, _sessionPool.GetSession());
+            var writer = Writer.Create(pipe.Writer, _sessionPool.GetSession());
             var writerCodec = CreateCodec();
             writerCodec.WriteField(ref writer, 0, typeof(TValue), original);
             writer.Commit();

--- a/src/Hagar/Buffers/Adaptors/ArrayBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/ArrayBufferWriter.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// An implementation of <see cref="IBufferWriter{byte}"/> which writes to an array.
+    /// </summary>
+    public struct ArrayBufferWriter : IBufferWriter<byte>
+    {
+        private readonly byte[] _buffer;
+        private int _bytesWritten;
+
+        internal ArrayBufferWriter(byte[] buffer)
+        {
+            _buffer = buffer;
+            _bytesWritten = 0;
+        }
+
+        public byte[] Buffer => _buffer;
+
+        public Memory<byte> Memory => _buffer.AsMemory(0, _bytesWritten);
+
+        public int BytesWritten => _bytesWritten;
+
+        public void Advance(int count)
+        {
+            if (_bytesWritten > _buffer.Length)
+            {
+                ThrowInvalidCount();
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                static void ThrowInvalidCount() => throw new InvalidOperationException("Cannot advance past the end of the buffer");
+            }
+
+            _bytesWritten += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _buffer.Length)
+            {
+                ThrowInsufficientCapacity(sizeHint);
+            }
+
+            return _buffer.AsMemory(_bytesWritten);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _buffer.Length)
+            {
+                ThrowInsufficientCapacity(sizeHint);
+            }
+
+            return _buffer.AsSpan(_bytesWritten);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInsufficientCapacity(int sizeHint) => throw new InvalidOperationException($"Insufficient capacity to perform the requested operation. Buffer size is {_buffer.Length}. Current length is {_bytesWritten} and requested size increase is {sizeHint}");
+    }
+}

--- a/src/Hagar/Buffers/Adaptors/ArrayStreamBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/ArrayStreamBufferWriter.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// An implementation of <see cref="IBufferWriter{byte}"/> which writes to a <see cref="Stream"/>, using an array as an intermediate buffer.
+    /// </summary>
+    public struct ArrayStreamBufferWriter : IBufferWriter<byte>
+    {
+        public const int DefaultInitialBufferSize = 256;
+        private readonly Stream _stream;
+        private byte[] _buffer;
+        private int _index;
+
+        public ArrayStreamBufferWriter(Stream stream, int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+            {
+                sizeHint = DefaultInitialBufferSize;
+            }
+
+            _stream = stream;
+            _buffer = new byte[sizeHint];
+            _index = 0;
+        }
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentException(nameof(count));
+            }
+
+            if (_index > _buffer.Length - count)
+            {
+                throw new InvalidOperationException("Cannot advance past the end of the current capacity");
+            }
+
+            _index += count;
+            _stream.Write(_buffer, 0, _index);
+            _index = 0;
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _buffer.AsMemory(_index);
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _buffer.AsSpan(_index);
+        }
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            if (sizeHint < 0)
+            {
+                throw new ArgumentException(nameof(sizeHint));
+            }
+
+            if (sizeHint == 0)
+            {
+                sizeHint = 1;
+            }
+
+            if (sizeHint > _buffer.Length - _index)
+            {
+                int growBy = Math.Max(sizeHint, _buffer.Length);
+
+                if (_buffer.Length == 0)
+                {
+                    growBy = Math.Max(growBy, DefaultInitialBufferSize);
+                }
+
+                int newSize = checked(_buffer.Length + growBy);
+
+                Array.Resize(ref _buffer, newSize);
+            }
+        }
+    }
+}

--- a/src/Hagar/Buffers/Adaptors/MemoryBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/MemoryBufferWriter.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// A <see cref="IBufferWriter{byte}"/> implementation for <see cref="Memory{byte}"/>
+    /// </summary>
+    public struct MemoryBufferWriter : IBufferWriter<byte>
+    {
+        private readonly Memory<byte> _buffer;
+        private int _bytesWritten;
+
+        internal MemoryBufferWriter(Memory<byte> buffer)
+        {
+            _buffer = buffer;
+            _bytesWritten = 0;
+        }
+
+        public int BytesWritten => _bytesWritten;
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            if (_bytesWritten > _buffer.Length)
+            {
+                ThrowInvalidCount();
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                static void ThrowInvalidCount() => throw new InvalidOperationException("Cannot advance past the end of the buffer");
+            }
+
+            _bytesWritten += count;
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _buffer.Length)
+            {
+                ThrowInsufficientCapacity(sizeHint);
+            }
+
+            return _buffer.Slice(_bytesWritten);
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _buffer.Length)
+            {
+                ThrowInsufficientCapacity(sizeHint);
+            }
+
+            return _buffer.Span.Slice(_bytesWritten);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInsufficientCapacity(int sizeHint) => throw new InvalidOperationException($"Insufficient capacity to perform the requested operation. Buffer size is {_buffer.Length}. Current length is {_bytesWritten} and requested size increase is {sizeHint}");
+    }
+}

--- a/src/Hagar/Buffers/Adaptors/MemoryStreamBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/MemoryStreamBufferWriter.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// An implementation of <see cref="IBufferWriter{byte}"/> which writes to a <see cref="MemoryStream"/>.
+    /// </summary>
+    public readonly struct MemoryStreamBufferWriter : IBufferWriter<byte>
+    {
+        private readonly MemoryStream _stream;
+        private const int MinRequestSize = 256;
+
+        public MemoryStreamBufferWriter(MemoryStream stream)
+        {
+            _stream = stream;
+        }
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            if (_stream.Position + count > _stream.Length)
+            {
+                //_stream.SetLength(_stream.Position + count);
+            }    
+
+            _stream.Position += count;
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint < MinRequestSize)
+            {
+                sizeHint = MinRequestSize;
+            }
+
+            if (_stream.Capacity - _stream.Position < sizeHint)
+            {
+                _stream.Capacity += sizeHint;
+                _stream.SetLength(_stream.Capacity);
+            }
+
+            return _stream.GetBuffer().AsMemory((int)_stream.Position);
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (sizeHint < MinRequestSize)
+            {
+                sizeHint = MinRequestSize;
+            }
+
+            if (_stream.Capacity - _stream.Position < sizeHint)
+            {
+                _stream.Capacity += sizeHint;
+                _stream.SetLength(_stream.Capacity);
+            }
+
+            return _stream.GetBuffer().AsSpan((int)_stream.Position);
+        }
+    }
+}

--- a/src/Hagar/Buffers/Adaptors/PooledArrayBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/PooledArrayBufferWriter.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// A <see cref="IBufferWriter{byte}"/> implementation implemented using pooled arrays.
+    /// </summary>
+    public struct PooledArrayBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        private byte[] _buffer;
+        private int _bytesWritten;
+        private const int MinRequestSize = 256;
+
+        internal PooledArrayBufferWriter(int sizeHint)
+        {
+            _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(sizeHint, MinRequestSize));
+            _bytesWritten = 0;
+        }
+
+        public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _bytesWritten);
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            _bytesWritten += count;
+            if (_bytesWritten > _buffer.Length)
+            {
+                ThrowInvalidCount();
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static void ThrowInvalidCount() => throw new InvalidOperationException("Cannot advance past the end of the buffer");
+            }
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _buffer.Length)
+            {
+                Resize(sizeHint);
+            }
+
+            return _buffer.AsMemory(_bytesWritten);
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _buffer.Length)
+            {
+                Resize(sizeHint);
+            }
+
+            return _buffer.AsSpan(_bytesWritten);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_buffer is object)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+            }
+        }
+
+        private void Resize(int sizeHint)
+        {
+            if (sizeHint < MinRequestSize)
+            {
+                sizeHint = MinRequestSize;
+            }
+
+            var newBuffer = ArrayPool<byte>.Shared.Rent(_bytesWritten + sizeHint);
+            _buffer.CopyTo(newBuffer, 0);
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = newBuffer;
+        }
+    }
+}

--- a/src/Hagar/Buffers/Adaptors/PoolingStreamBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/PoolingStreamBufferWriter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// An implementation of <see cref="IBufferWriter{byte}"/> for writing to a <see cref="Stream"/>, using pooled arrays as an intermediate buffer.
+    /// </summary>
+    public struct PoolingStreamBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        private readonly Stream _stream;
+        private byte[] _buffer;
+        private int _bytesWritten;
+        private const int MinRequestSize = 256;
+
+        internal PoolingStreamBufferWriter(Stream stream, int sizeHint)
+        {
+            _stream = stream;
+            _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(sizeHint, MinRequestSize));
+            _bytesWritten = 0;
+        }
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            _stream.Write(_buffer, _bytesWritten, count);
+            _bytesWritten += count;
+            if (_bytesWritten > _buffer.Length)
+            {
+                ThrowInvalidCount();
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                static void ThrowInvalidCount() => throw new InvalidOperationException("Cannot advance past the end of the buffer");
+            }
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint < MinRequestSize)
+            {
+                sizeHint = MinRequestSize;
+            }
+
+            if (sizeHint <= _buffer.Length - _bytesWritten)
+            {
+                return _buffer.AsMemory(_bytesWritten);
+            }
+            else
+            {
+                _bytesWritten = 0;
+                Resize(sizeHint);
+                return _buffer;
+            }
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (sizeHint < MinRequestSize)
+            {
+                sizeHint = MinRequestSize;
+            }
+
+            if (sizeHint <= _buffer.Length - _bytesWritten)
+            {
+                return _buffer.AsSpan(_bytesWritten);
+            }
+            else
+            {
+                _bytesWritten = 0;
+                Resize(sizeHint);
+                return _buffer;
+            }
+        }
+
+        private void Resize(int sizeHint)
+        {
+            var newBuffer = ArrayPool<byte>.Shared.Rent(_bytesWritten + sizeHint);
+            _buffer.CopyTo(newBuffer, 0);
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = newBuffer;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_buffer is object)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+            }
+        }
+    }
+}

--- a/src/Hagar/Buffers/Adaptors/SpanBufferWriter.cs
+++ b/src/Hagar/Buffers/Adaptors/SpanBufferWriter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Buffers;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+
+namespace Hagar.Buffers.Adaptors
+{
+    /// <summary>
+    /// A special-purpose <see cref="IBufferWriter{byte}"/> implementation for supporting <see cref="Span{Byte}"/> in <see cref="Writer{TBufferWriter}"/>.
+    /// </summary>
+    public struct SpanBufferWriter : IBufferWriter<byte>
+    {
+        private int _maxLength;
+        private int _bytesWritten;
+
+        internal SpanBufferWriter(Span<byte> buffer)
+        {
+            _maxLength = buffer.Length;
+            _bytesWritten = 0;
+        }
+
+        public int BytesWritten => _bytesWritten;
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            if (_bytesWritten + count > _maxLength)
+            {
+                ThrowInvalidCount();
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                static void ThrowInvalidCount() => throw new InvalidOperationException("Cannot advance past the end of the buffer");
+            }
+
+            _bytesWritten += count;
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _maxLength)
+            {
+                ThrowInsufficientCapacity(sizeHint);
+            }
+
+            throw new NotSupportedException("Method is not supported on this instance");
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (_bytesWritten + sizeHint > _maxLength)
+            {
+                ThrowInsufficientCapacity(sizeHint);
+            }
+
+            throw new NotSupportedException("Method is not supported on this instance");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowInsufficientCapacity(int sizeHint) => throw new InvalidOperationException($"Insufficient capacity to perform the requested operation. Buffer size is {_maxLength}. Current length is {_bytesWritten} and requested size increase is {sizeHint}");
+    }
+}

--- a/src/Hagar/Buffers/BufferWriterExtensions.cs
+++ b/src/Hagar/Buffers/BufferWriterExtensions.cs
@@ -15,7 +15,7 @@ namespace Hagar.Buffers
                 ThrowSessionNull();
             }
 
-            return new Writer<TBufferWriter>(buffer, session);
+            return Writer.Create(buffer, session);
 
             void ThrowSessionNull() => throw new ArgumentNullException(nameof(session));
         }

--- a/src/Hagar/Buffers/Writer.cs
+++ b/src/Hagar/Buffers/Writer.cs
@@ -11,6 +11,13 @@ using Hagar.Utilities;
 
 namespace Hagar.Buffers
 {
+
+    public static class Writer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Writer<TBufferWriter> Create<TBufferWriter>(TBufferWriter output, SerializerSession session) where TBufferWriter : IBufferWriter<byte> => new Writer<TBufferWriter>(output, session);
+    }
+
     public ref struct Writer<TBufferWriter> where TBufferWriter : IBufferWriter<byte>
     {
 #pragma warning disable IDE0044 // Add readonly modifier
@@ -20,7 +27,7 @@ namespace Hagar.Buffers
         private int _bufferPos;
         private int _previousBuffersSize;
 
-        public Writer(TBufferWriter output, SerializerSession session)
+        internal Writer(TBufferWriter output, SerializerSession session)
         {
             _output = output;
             Session = session;

--- a/src/Hagar/Codecs/AbstractCodecAdapter.cs
+++ b/src/Hagar/Codecs/AbstractCodecAdapter.cs
@@ -30,6 +30,6 @@ namespace Hagar.Codecs
             _codec.WriteField(ref writer, fieldIdDelta, expectedType, value);
 
         /// <inheritdoc />
-        public TConcrete ReadValue(ref Reader reader, Field field) => (TConcrete)_codec.ReadValue(ref reader, field);
+        public TConcrete ReadValue<TInput>(ref Reader<TInput> reader, Field field) => (TConcrete)_codec.ReadValue(ref reader, field);
     }
 }

--- a/src/Hagar/Codecs/ArrayCodec.cs
+++ b/src/Hagar/Codecs/ArrayCodec.cs
@@ -38,11 +38,11 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        T[] IFieldCodec<T[]>.ReadValue(ref Reader reader, Field field)
+        T[] IFieldCodec<T[]>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<T[]>(ref reader, field);
+                return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.TagDelimited)

--- a/src/Hagar/Codecs/ByteArrayCodec.cs
+++ b/src/Hagar/Codecs/ByteArrayCodec.cs
@@ -7,13 +7,13 @@ namespace Hagar.Codecs
 {
     public sealed class ByteArrayCodec : TypedCodecBase<byte[], ByteArrayCodec>, IFieldCodec<byte[]>
     {
-        byte[] IFieldCodec<byte[]>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        byte[] IFieldCodec<byte[]>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static byte[] ReadValue(ref Reader reader, Field field)
+        public static byte[] ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<byte[]>(ref reader, field);
+                return ReferenceCodec.ReadReference<byte[], TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.LengthPrefixed)

--- a/src/Hagar/Codecs/CodecAdapter.cs
+++ b/src/Hagar/Codecs/CodecAdapter.cs
@@ -31,7 +31,7 @@ namespace Hagar.Codecs
 
             void IFieldCodec<object>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) => _codec.WriteField(ref writer, fieldIdDelta, expectedType, (TField)value);
 
-            object IFieldCodec<object>.ReadValue(ref Reader reader, Field field) => _codec.ReadValue(ref reader, field);
+            object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => _codec.ReadValue(ref reader, field);
 
             public object InnerCodec => _codec;
         }
@@ -49,7 +49,7 @@ namespace Hagar.Codecs
 
             void IFieldCodec<TField>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) => _codec.WriteField(ref writer, fieldIdDelta, expectedType, value);
 
-            TField IFieldCodec<TField>.ReadValue(ref Reader reader, Field field) => (TField)_codec.ReadValue(ref reader, field);
+            TField IFieldCodec<TField>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => (TField)_codec.ReadValue(ref reader, field);
         }
     }
 }

--- a/src/Hagar/Codecs/ConsumeFieldExtension.cs
+++ b/src/Hagar/Codecs/ConsumeFieldExtension.cs
@@ -8,7 +8,7 @@ namespace Hagar.Codecs
         /// <summary>
         /// Consumes an unknown field.
         /// </summary>
-        public static void ConsumeUnknownField(this ref Reader reader, Field field)
+        public static void ConsumeUnknownField<TInput>(this ref Reader<TInput> reader, Field field)
         {
             // References cannot themselves be referenced.
             if (field.WireType == WireType.Reference)
@@ -53,7 +53,7 @@ namespace Hagar.Codecs
         /// <summary>
         /// Consumes a tag-delimited field.
         /// </summary>
-        private static void ConsumeTagDelimitedField(this ref Reader reader)
+        private static void ConsumeTagDelimitedField<TInput>(this ref Reader<TInput> reader)
         {
             while (true)
             {

--- a/src/Hagar/Codecs/DateTimeCodec.cs
+++ b/src/Hagar/Codecs/DateTimeCodec.cs
@@ -16,9 +16,9 @@ namespace Hagar.Codecs
             writer.Write(value.ToBinary());
         }
 
-        DateTime IFieldCodec<DateTime>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        DateTime IFieldCodec<DateTime>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static DateTime ReadValue(ref Reader reader, Field field)
+        public static DateTime ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             if (field.WireType != WireType.Fixed64)

--- a/src/Hagar/Codecs/DateTimeOffsetCodec.cs
+++ b/src/Hagar/Codecs/DateTimeOffsetCodec.cs
@@ -18,9 +18,9 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        DateTimeOffset IFieldCodec<DateTimeOffset>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        DateTimeOffset IFieldCodec<DateTimeOffset>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static DateTimeOffset ReadValue(ref Reader reader, Field field)
+        public static DateTimeOffset ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             if (field.WireType != WireType.TagDelimited)

--- a/src/Hagar/Codecs/DictionaryCodec.cs
+++ b/src/Hagar/Codecs/DictionaryCodec.cs
@@ -52,11 +52,11 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Dictionary<TKey, TValue> IFieldCodec<Dictionary<TKey, TValue>>.ReadValue(ref Reader reader, Field field)
+        Dictionary<TKey, TValue> IFieldCodec<Dictionary<TKey, TValue>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<Dictionary<TKey, TValue>>(ref reader, field);
+                return ReferenceCodec.ReadReference<Dictionary<TKey, TValue>, TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.TagDelimited)

--- a/src/Hagar/Codecs/FieldHeaderCodec.cs
+++ b/src/Hagar/Codecs/FieldHeaderCodec.cs
@@ -90,7 +90,7 @@ namespace Hagar.Codecs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ReadFieldHeader(ref this Reader reader, ref Field field)
+        public static void ReadFieldHeader<TInput>(ref this Reader<TInput> reader, ref Field field)
         {
             var tag = reader.ReadByte();
 
@@ -108,7 +108,7 @@ namespace Hagar.Codecs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Field ReadFieldHeader(ref this Reader reader)
+        public static Field ReadFieldHeader<TInput>(ref this Reader<TInput> reader)
         {
             Field field = default;
             var tag = reader.ReadByte();
@@ -128,7 +128,7 @@ namespace Hagar.Codecs
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ReadFieldHeaderSlow(ref this Reader reader, ref Field field)
+        private static void ReadFieldHeaderSlow<TInput>(ref this Reader<TInput> reader, ref Field field)
         {
             // If all of the field id delta bits are set and the field isn't an extended wiretype field, read the extended field id delta
             var notExtended = (field.Tag & (byte)WireType.Extended) != (byte)WireType.Extended;
@@ -154,7 +154,7 @@ namespace Hagar.Codecs
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static Type ReadType(this ref Reader reader, SchemaType schemaType)
+        private static Type ReadType<TInput>(this ref Reader<TInput> reader, SchemaType schemaType)
         {
             switch (schemaType)
             {

--- a/src/Hagar/Codecs/FloatCodec.cs
+++ b/src/Hagar/Codecs/FloatCodec.cs
@@ -21,9 +21,9 @@ namespace Hagar.Codecs
             writer.Write((uint)BitConverter.ToInt32(BitConverter.GetBytes(value), 0));
         }
 
-        float IFieldCodec<float>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        float IFieldCodec<float>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static float ReadValue(ref Reader reader, Field field)
+        public static float ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             switch (field.WireType)
@@ -74,9 +74,9 @@ namespace Hagar.Codecs
             writer.Write((ulong)BitConverter.ToInt64(BitConverter.GetBytes(value), 0));
         }
 
-        double IFieldCodec<double>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        double IFieldCodec<double>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static double ReadValue(ref Reader reader, Field field)
+        public static double ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             switch (field.WireType)
@@ -112,9 +112,9 @@ namespace Hagar.Codecs
             }
         }
 
-        decimal IFieldCodec<decimal>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        decimal IFieldCodec<decimal>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static decimal ReadValue(ref Reader reader, Field field)
+        public static decimal ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             switch (field.WireType)

--- a/src/Hagar/Codecs/GuidCodec.cs
+++ b/src/Hagar/Codecs/GuidCodec.cs
@@ -26,9 +26,9 @@ namespace Hagar.Codecs
             writer.Write(value.ToByteArray());
         }
 
-        Guid IFieldCodec<Guid>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        Guid IFieldCodec<Guid>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static Guid ReadValue(ref Reader reader, Field field)
+        public static Guid ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
 #if NETCOREAPP

--- a/src/Hagar/Codecs/IFieldCodec.cs
+++ b/src/Hagar/Codecs/IFieldCodec.cs
@@ -12,6 +12,6 @@ namespace Hagar.Codecs
     public interface IFieldCodec<T> : IFieldCodec
     {
         void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, T value) where TBufferWriter : IBufferWriter<byte>;
-        T ReadValue(ref Reader reader, Field field);
+        T ReadValue<TInput>(ref Reader<TInput> reader, Field field);
     }
 }

--- a/src/Hagar/Codecs/IntegerCodec.cs
+++ b/src/Hagar/Codecs/IntegerCodec.cs
@@ -20,9 +20,9 @@ namespace Hagar.Codecs
             writer.WriteVarInt(value ? 1 : 0);
         }
 
-        bool IFieldCodec<bool>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        bool IFieldCodec<bool>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static bool ReadValue(ref Reader reader, Field field)
+        public static bool ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt8(field.WireType) == 1;
@@ -43,9 +43,9 @@ namespace Hagar.Codecs
             writer.WriteVarInt(value);
         }
 
-        char IFieldCodec<char>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        char IFieldCodec<char>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static char ReadValue(ref Reader reader, Field field)
+        public static char ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return (char)reader.ReadUInt16(field.WireType);
@@ -66,9 +66,9 @@ namespace Hagar.Codecs
             writer.WriteVarInt(value);
         }
 
-        byte IFieldCodec<byte>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        byte IFieldCodec<byte>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static byte ReadValue(ref Reader reader, Field field)
+        public static byte ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt8(field.WireType);
@@ -89,9 +89,9 @@ namespace Hagar.Codecs
             writer.WriteVarInt(value);
         }
 
-        sbyte IFieldCodec<sbyte>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        sbyte IFieldCodec<sbyte>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static sbyte ReadValue(ref Reader reader, Field field)
+        public static sbyte ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt8(field.WireType);
@@ -100,9 +100,9 @@ namespace Hagar.Codecs
 
     public sealed class UInt16Codec : TypedCodecBase<ushort, UInt16Codec>, IFieldCodec<ushort>
     {
-        ushort IFieldCodec<ushort>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        ushort IFieldCodec<ushort>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static ushort ReadValue(ref Reader reader, Field field)
+        public static ushort ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt16(field.WireType);
@@ -135,9 +135,9 @@ namespace Hagar.Codecs
             writer.WriteVarInt(value);
         }
 
-        short IFieldCodec<short>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        short IFieldCodec<short>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static short ReadValue(ref Reader reader, Field field)
+        public static short ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt16(field.WireType);
@@ -166,9 +166,9 @@ namespace Hagar.Codecs
             }
         }
 
-        uint IFieldCodec<uint>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        uint IFieldCodec<uint>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static uint ReadValue(ref Reader reader, Field field)
+        public static uint ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt32(field.WireType);
@@ -214,9 +214,9 @@ namespace Hagar.Codecs
             }
         }
 
-        int IFieldCodec<int>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        int IFieldCodec<int>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static int ReadValue(ref Reader reader, Field field)
+        public static int ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt32(field.WireType);
@@ -255,9 +255,9 @@ namespace Hagar.Codecs
             }
         }
 
-        long IFieldCodec<long>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        long IFieldCodec<long>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static long ReadValue(ref Reader reader, Field field)
+        public static long ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadInt64(field.WireType);
@@ -299,9 +299,9 @@ namespace Hagar.Codecs
             }
         }
 
-        ulong IFieldCodec<ulong>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        ulong IFieldCodec<ulong>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static ulong ReadValue(ref Reader reader, Field field)
+        public static ulong ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             return reader.ReadUInt64(field.WireType);

--- a/src/Hagar/Codecs/KeyValuePairCodec.cs
+++ b/src/Hagar/Codecs/KeyValuePairCodec.cs
@@ -31,7 +31,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        public KeyValuePair<TKey, TValue> ReadValue(ref Reader reader, Field field)
+        public KeyValuePair<TKey, TValue> ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {

--- a/src/Hagar/Codecs/ListCodec.cs
+++ b/src/Hagar/Codecs/ListCodec.cs
@@ -43,11 +43,11 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        List<T> IFieldCodec<List<T>>.ReadValue(ref Reader reader, Field field)
+        List<T> IFieldCodec<List<T>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<List<T>>(ref reader, field);
+                return ReferenceCodec.ReadReference<List<T>, TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.TagDelimited)

--- a/src/Hagar/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Hagar/Codecs/MultiDimensionalArrayCodec.cs
@@ -72,11 +72,11 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        object IFieldCodec<object>.ReadValue(ref Reader reader, Field field)
+        object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<T[]>(ref reader, field);
+                return ReferenceCodec.ReadReference<T[], TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.TagDelimited)

--- a/src/Hagar/Codecs/ObjectCodec.cs
+++ b/src/Hagar/Codecs/ObjectCodec.cs
@@ -9,13 +9,13 @@ namespace Hagar.Codecs
     {
         private static readonly Type ObjectType = typeof(object);
 
-        object IFieldCodec<object>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static object ReadValue(ref Reader reader, Field field)
+        public static object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<object>(ref reader, field);
+                return ReferenceCodec.ReadReference<object, TInput>(ref reader, field);
             }
 
             if (field.FieldType == ObjectType || field.FieldType is null)

--- a/src/Hagar/Codecs/ReferenceCodec.cs
+++ b/src/Hagar/Codecs/ReferenceCodec.cs
@@ -34,10 +34,10 @@ namespace Hagar.Codecs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ReadReference<T>(ref Reader reader, Field field) => (T)ReadReference(ref reader, field, typeof(T));
+        public static T ReadReference<T, TInput>(ref Reader<TInput> reader, Field field) => (T)ReadReference(ref reader, field, typeof(T));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static object ReadReference(ref Reader reader, Field field, Type expectedType)
+        public static object ReadReference<TInput>(ref Reader<TInput> reader, Field field, Type expectedType)
         {
             var reference = reader.ReadVarUInt32();
             if (!reader.Session.ReferencedObjects.TryGetReferencedObject(reference, out var value))
@@ -52,8 +52,8 @@ namespace Hagar.Codecs
             };
         }
 
-        private static object DeserializeFromMarker(
-            ref Reader reader,
+        private static object DeserializeFromMarker<TInput>(
+            ref Reader<TInput> reader,
             Field field,
             UnknownFieldMarker marker,
             uint reference,
@@ -69,7 +69,7 @@ namespace Hagar.Codecs
             var session = reader.Session;
             var specificSerializer = session.CodecProvider.GetCodec(fieldType);
 
-            // Reset the session's reference id so that the deserialized object overwrites the marker.
+            // Reset the session's reference id so that the deserialized objects overwrite the placeholder markers.
             var referencedObjects = session.ReferencedObjects;
             var originalCurrentReferenceId = referencedObjects.CurrentReferenceId;
             var originalReferenceToObjectCount = referencedObjects.ReferenceToObjectCount;

--- a/src/Hagar/Codecs/SkipFieldExtension.cs
+++ b/src/Hagar/Codecs/SkipFieldExtension.cs
@@ -13,7 +13,7 @@ namespace Hagar.Codecs
             throw new NotImplementedException();
         }
 
-        public object ReadValue(ref Reader reader, Field field)
+        public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             reader.SkipField(field);
@@ -23,7 +23,7 @@ namespace Hagar.Codecs
 
     public static class SkipFieldExtension
     {
-        public static void SkipField(this ref Reader reader, Field field)
+        public static void SkipField<TInput>(this ref Reader<TInput> reader, Field field)
         {
             switch (field.WireType)
             {
@@ -65,13 +65,13 @@ namespace Hagar.Codecs
         internal static void ThrowUnexpectedWireType(Field field) => throw new ArgumentOutOfRangeException(
                 $"Unexpected {nameof(WireType)} value [{field.WireType}] in field {field} while skipping field.");
 
-        internal static void SkipLengthPrefixedField(ref Reader reader)
+        internal static void SkipLengthPrefixedField<TInput>(ref Reader<TInput> reader)
         {
             var length = reader.ReadVarUInt32();
             reader.Skip(length);
         }
 
-        private static void SkipTagDelimitedField(ref Reader reader)
+        private static void SkipTagDelimitedField<TInput>(ref Reader<TInput> reader)
         {
             while (true)
             {

--- a/src/Hagar/Codecs/StringCodec.cs
+++ b/src/Hagar/Codecs/StringCodec.cs
@@ -9,14 +9,14 @@ namespace Hagar.Codecs
 {
     public sealed class StringCodec : TypedCodecBase<string, StringCodec>, IFieldCodec<string>
     {
-        string IFieldCodec<string>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        string IFieldCodec<string>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ReadValue(ref Reader reader, Field field)
+        public static string ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<string>(ref reader, field);
+                return ReferenceCodec.ReadReference<string, TInput>(ref reader, field);
             }
 
             if (field.WireType != WireType.LengthPrefixed)

--- a/src/Hagar/Codecs/TimeSpanCodec.cs
+++ b/src/Hagar/Codecs/TimeSpanCodec.cs
@@ -16,9 +16,9 @@ namespace Hagar.Codecs
             writer.Write(value.Ticks);
         }
 
-        TimeSpan IFieldCodec<TimeSpan>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        TimeSpan IFieldCodec<TimeSpan>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static TimeSpan ReadValue(ref Reader reader, Field field)
+        public static TimeSpan ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             if (field.WireType != WireType.Fixed64)

--- a/src/Hagar/Codecs/TupleCodec.cs
+++ b/src/Hagar/Codecs/TupleCodec.cs
@@ -28,7 +28,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T> IFieldCodec<Tuple<T>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T> IFieldCodec<Tuple<T>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -93,7 +93,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2> IFieldCodec<Tuple<T1, T2>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2> IFieldCodec<Tuple<T1, T2>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -168,7 +168,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2, T3> IFieldCodec<Tuple<T1, T2, T3>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2, T3> IFieldCodec<Tuple<T1, T2, T3>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -251,7 +251,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2, T3, T4> IFieldCodec<Tuple<T1, T2, T3, T4>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2, T3, T4> IFieldCodec<Tuple<T1, T2, T3, T4>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -345,7 +345,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2, T3, T4, T5> IFieldCodec<Tuple<T1, T2, T3, T4, T5>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2, T3, T4, T5> IFieldCodec<Tuple<T1, T2, T3, T4, T5>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -447,7 +447,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2, T3, T4, T5, T6> IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2, T3, T4, T5, T6> IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -558,7 +558,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2, T3, T4, T5, T6, T7> IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6, T7>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2, T3, T4, T5, T6, T7> IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6, T7>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -677,7 +677,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Tuple<T1, T2, T3, T4, T5, T6, T7, T8> IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>>.ReadValue(ref Reader reader, Field field)
+        Tuple<T1, T2, T3, T4, T5, T6, T7, T8> IFieldCodec<Tuple<T1, T2, T3, T4, T5, T6, T7, T8>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {

--- a/src/Hagar/Codecs/TypeSerializerCodec.cs
+++ b/src/Hagar/Codecs/TypeSerializerCodec.cs
@@ -48,13 +48,13 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        Type IFieldCodec<Type>.ReadValue(ref Reader reader, Field field) => ReadValue(ref reader, field);
+        Type IFieldCodec<Type>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => ReadValue(ref reader, field);
 
-        public static Type ReadValue(ref Reader reader, Field field)
+        public static Type ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<Type>(ref reader, field);
+                return ReferenceCodec.ReadReference<Type, TInput>(ref reader, field);
             }
 
             uint fieldId = 0;

--- a/src/Hagar/Codecs/TypedCodecBase.cs
+++ b/src/Hagar/Codecs/TypedCodecBase.cs
@@ -19,7 +19,7 @@ namespace Hagar.Codecs
 
         void IFieldCodec<object>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) => _codec.WriteField(ref writer, fieldIdDelta, expectedType, (TField)value);
 
-        object IFieldCodec<object>.ReadValue(ref Reader reader, Field field) => _codec.ReadValue(ref reader, field);
+        object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field) => _codec.ReadValue(ref reader, field);
 
         private static void ThrowInvalidSubclass() => throw new InvalidCastException($"Subclasses of {typeof(TypedCodecBase<TField, TCodec>)} must implement/derive from {typeof(TCodec)}.");
     }

--- a/src/Hagar/Codecs/ValueTupleCodec.cs
+++ b/src/Hagar/Codecs/ValueTupleCodec.cs
@@ -14,7 +14,7 @@ namespace Hagar.Codecs
             writer.WriteVarInt(0);
         }
 
-        ValueTuple IFieldCodec<ValueTuple>.ReadValue(ref Reader reader, Field field)
+        ValueTuple IFieldCodec<ValueTuple>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.VarInt)
             {
@@ -54,7 +54,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        ValueTuple<T> IFieldCodec<ValueTuple<T>>.ReadValue(ref Reader reader, Field field)
+        ValueTuple<T> IFieldCodec<ValueTuple<T>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -117,7 +117,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        (T1, T2) IFieldCodec<ValueTuple<T1, T2>>.ReadValue(ref Reader reader, Field field)
+        (T1, T2) IFieldCodec<ValueTuple<T1, T2>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -190,7 +190,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        (T1, T2, T3) IFieldCodec<ValueTuple<T1, T2, T3>>.ReadValue(ref Reader reader, Field field)
+        (T1, T2, T3) IFieldCodec<ValueTuple<T1, T2, T3>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -271,7 +271,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        (T1, T2, T3, T4) IFieldCodec<ValueTuple<T1, T2, T3, T4>>.ReadValue(ref Reader reader, Field field)
+        (T1, T2, T3, T4) IFieldCodec<ValueTuple<T1, T2, T3, T4>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -359,7 +359,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        (T1, T2, T3, T4, T5) IFieldCodec<ValueTuple<T1, T2, T3, T4, T5>>.ReadValue(ref Reader reader, Field field)
+        (T1, T2, T3, T4, T5) IFieldCodec<ValueTuple<T1, T2, T3, T4, T5>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -456,7 +456,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        (T1, T2, T3, T4, T5, T6) IFieldCodec<ValueTuple<T1, T2, T3, T4, T5, T6>>.ReadValue(ref Reader reader, Field field)
+        (T1, T2, T3, T4, T5, T6) IFieldCodec<ValueTuple<T1, T2, T3, T4, T5, T6>>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.TagDelimited)
             {
@@ -561,8 +561,8 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        (T1, T2, T3, T4, T5, T6, T7) IFieldCodec<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>.ReadValue(
-            ref Reader reader,
+        (T1, T2, T3, T4, T5, T6, T7) IFieldCodec<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>.ReadValue<TInput>(
+            ref Reader<TInput> reader,
             Field field)
         {
             if (field.WireType != WireType.TagDelimited)
@@ -676,7 +676,7 @@ namespace Hagar.Codecs
             writer.WriteEndObject();
         }
 
-        ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> IFieldCodec<ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>>.ReadValue(ref Reader reader,
+        ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8> IFieldCodec<ValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>>.ReadValue<TInput>(ref Reader<TInput> reader,
             Field field)
         {
             if (field.WireType != WireType.TagDelimited)

--- a/src/Hagar/Codecs/VoidCodec.cs
+++ b/src/Hagar/Codecs/VoidCodec.cs
@@ -14,14 +14,14 @@ namespace Hagar.Codecs
             }
         }
 
-        object IFieldCodec<object>.ReadValue(ref Reader reader, Field field)
+        object IFieldCodec<object>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType != WireType.Reference)
             {
                 ThrowInvalidWireType(field);
             }
 
-            return ReferenceCodec.ReadReference<object>(ref reader, field);
+            return ReferenceCodec.ReadReference<object, TInput>(ref reader, field);
         }
 
         private static void ThrowInvalidWireType(Field field) => throw new UnsupportedWireTypeException($"Expected a reference, but encountered wire type of '{field.WireType}'.");

--- a/src/Hagar/Hagar.csproj
+++ b/src/Hagar/Hagar.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48'" >
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>

--- a/src/Hagar/Hosting/ServiceProviderExtensions.cs
+++ b/src/Hagar/Hosting/ServiceProviderExtensions.cs
@@ -119,7 +119,7 @@ namespace Hagar
 
             public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte> => Value.WriteField(ref writer, fieldIdDelta, expectedType, value);
 
-            public TField ReadValue(ref Reader reader, Field field) => Value.ReadValue(ref reader, field);
+            public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field) => Value.ReadValue(ref reader, field);
 
             public IFieldCodec<TField> Value => _codec ??= _codecProvider.GetCodec<TField>();
         }
@@ -136,7 +136,7 @@ namespace Hagar
 
             public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, TField value) where TBufferWriter : IBufferWriter<byte> => Value.Serialize(ref writer, value);
 
-            public void Deserialize(ref Reader reader, TField value) => Value.Deserialize(ref reader, value);
+            public void Deserialize<TInput>(ref Reader<TInput> reader, TField value) => Value.Deserialize(ref reader, value);
 
             public IPartialSerializer<TField> Value => _partialSerializer ??= _provider.GetPartialSerializer<TField>();
         }
@@ -153,7 +153,7 @@ namespace Hagar
 
             public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, in TField value) where TBufferWriter : IBufferWriter<byte> => Value.Serialize(ref writer, in value);
 
-            public void Deserialize(ref Reader reader, ref TField value) => Value.Deserialize(ref reader, ref value);
+            public void Deserialize<TInput>(ref Reader<TInput> reader, ref TField value) => Value.Deserialize(ref reader, ref value);
 
             public IValueSerializer<TField> Value => _serializer ??= _provider.GetValueSerializer<TField>();
         }

--- a/src/Hagar/Invocation/PooledResponseCodec.cs
+++ b/src/Hagar/Invocation/PooledResponseCodec.cs
@@ -31,7 +31,7 @@ namespace Hagar.Invocation
             }
         }
 
-        public void Deserialize(ref Buffers.Reader reader, PooledResponse<TResult> instance)
+        public void Deserialize<TInput>(ref Buffers.Reader<TInput> reader, PooledResponse<TResult> instance)
         {
             uint fieldId = 0;
             while (true)

--- a/src/Hagar/Serializer.cs
+++ b/src/Hagar/Serializer.cs
@@ -2,12 +2,64 @@ using Hagar.Buffers;
 using Hagar.Codecs;
 using Hagar.GeneratedCodeHelpers;
 using Hagar.Serializers;
+using Hagar.Session;
 using Hagar.WireProtocol;
 using System;
 using System.Buffers;
+using System.IO;
 
 namespace Hagar
 {
+    public sealed class Serializer 
+    {
+        private readonly SessionPool _sessionPool;
+        private readonly ICodecProvider _codecProvider;
+
+        public byte[] SerializeToByteArray<T>(T value)
+        {
+            return default;
+        }
+
+        public T Deserialize<T>(byte[] source) => Deserialize<T>(new ReadOnlyMemory<byte>(source));
+        
+        public T Deserialize<T>(ReadOnlyMemory<byte> source)
+        {
+            var sequence = new ReadOnlySequence<byte>(source);
+            using var session = _sessionPool.GetSession();
+            var reader = new Reader(sequence, session);
+            var codec = _codecProvider.GetCodec<T>();
+            var field = reader.ReadFieldHeader();
+            return codec.ReadValue(ref reader, field);
+        }
+
+        public void Serialize<T>(T value, Stream destination)
+        {
+
+        }
+
+        public T Deserialize<T>(Stream source)
+        {
+            return default;
+        }
+
+        public void Serialize<T>(T value, IBufferWriter<byte> destination)
+        {
+            using var session = _sessionPool.GetSession();
+            var writer = new Writer<IBufferWriter<byte>>(destination, session);
+            var codec = _codecProvider.GetCodec<T>();
+            codec.WriteField(ref writer, 0, typeof(T), value);
+        }
+
+        public T Deserialize<T>(ReadOnlySequence<byte> source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = new Reader(source, session);
+            var codec = _codecProvider.GetCodec<T>();
+            var field = reader.ReadFieldHeader();
+            return codec.ReadValue(ref reader, field);
+        }
+    }
+
     public sealed class Serializer<T>
     {
         private readonly IFieldCodec<T> _codec;

--- a/src/Hagar/Serializer.cs
+++ b/src/Hagar/Serializer.cs
@@ -45,7 +45,7 @@ namespace Hagar
         public void Serialize<T>(T value, IBufferWriter<byte> destination)
         {
             using var session = _sessionPool.GetSession();
-            var writer = new Writer<IBufferWriter<byte>>(destination, session);
+            var writer = Writer.Create(destination, session);
             var codec = _codecProvider.GetCodec<T>();
             codec.WriteField(ref writer, 0, typeof(T), value);
         }

--- a/src/Hagar/Serializer.cs
+++ b/src/Hagar/Serializer.cs
@@ -1,4 +1,5 @@
 using Hagar.Buffers;
+using Hagar.Buffers.Adaptors;
 using Hagar.Codecs;
 using Hagar.GeneratedCodeHelpers;
 using Hagar.Serializers;
@@ -15,41 +16,134 @@ namespace Hagar
         private readonly SessionPool _sessionPool;
         private readonly ICodecProvider _codecProvider;
 
-        public byte[] SerializeToByteArray<T>(T value)
+        public Serializer(SessionPool sessionPool, ICodecProvider codecProvider)
         {
-            return default;
+            _sessionPool = sessionPool;
+            _codecProvider = codecProvider;
         }
 
-        public T Deserialize<T>(byte[] source) => Deserialize<T>(new ReadOnlyMemory<byte>(source));
-        
-        public T Deserialize<T>(ReadOnlyMemory<byte> source)
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into a new array.
+        /// </summary>
+        /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="sizeHint">The estimated upper bound for the length of the serialized data.</param>
+        /// <returns>A byte array containing the serialized value.</returns>
+        public byte[] SerializeToArray<T>(T value, int sizeHint = 0)
         {
-            var sequence = new ReadOnlySequence<byte>(source);
+            using var buffer = new PooledArrayBufferWriter(sizeHint);
             using var session = _sessionPool.GetSession();
-            var reader = Reader.Create(sequence, session);
+            var writer = Writer.Create(buffer, session);
             var codec = _codecProvider.GetCodec<T>();
-            var field = reader.ReadFieldHeader();
-            return codec.ReadValue(ref reader, field);
+            codec.WriteField(ref writer, 0, typeof(T), value);
+            writer.Commit();
+
+            // Copy the result into a fresh array.
+            var written = buffer.WrittenSpan;
+            var result = new byte[written.Length];
+            written.CopyTo(result);
+
+            return result;
         }
 
-        public void Serialize<T>(T value, Stream destination)
-        {
-
-        }
-
-        public T Deserialize<T>(Stream source)
-        {
-            return default;
-        }
-
-        public void Serialize<T>(T value, IBufferWriter<byte> destination)
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
+        public void Serialize<T>(T value, ref Memory<byte> destination)
         {
             using var session = _sessionPool.GetSession();
             var writer = Writer.Create(destination, session);
             var codec = _codecProvider.GetCodec<T>();
             codec.WriteField(ref writer, 0, typeof(T), value);
+            writer.Commit();
+            destination = destination.Slice(0, writer.Position);
         }
 
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        /// <param name="sizeHint">The estimated upper bound for the length of the serialized data.</param>
+        /// <remarks>The destination stream will not be flushed by this method.</remarks>
+        public void Serialize<T>(T value, Stream destination, int sizeHint = 0)
+        {
+            if (destination is MemoryStream memoryStream)
+            {
+                var buffer = new MemoryStreamBufferWriter(memoryStream);
+                using var session = _sessionPool.GetSession();
+                var writer = Writer.Create(buffer, session);
+                var codec = _codecProvider.GetCodec<T>();
+                codec.WriteField(ref writer, 0, typeof(T), value);
+                writer.Commit();
+            }
+            else
+            {
+                using var buffer = new PoolingStreamBufferWriter(destination, sizeHint);
+                using var session = _sessionPool.GetSession();
+                var writer = Writer.Create(buffer, session);
+                var codec = _codecProvider.GetCodec<T>();
+                codec.WriteField(ref writer, 0, typeof(T), value);
+                writer.Commit();
+            }
+        }
+
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
+        /// <typeparam name="TBufferWriter">The output buffer writer.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        public void Serialize<T, TBufferWriter>(T value, TBufferWriter destination) where TBufferWriter : IBufferWriter<byte>
+        {
+            using var session = _sessionPool.GetSession();
+            var writer = Writer.Create(destination, session);
+            var codec = _codecProvider.GetCodec<T>();
+            codec.WriteField(ref writer, 0, typeof(T), value);
+            writer.Commit();
+        }
+
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
+        /// <typeparam name="TBufferWriter">The output buffer writer.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        public void Serialize<T, TBufferWriter>(in T value, ref Writer<TBufferWriter> destination) where TBufferWriter : IBufferWriter<byte>
+        {
+            var codec = _codecProvider.GetCodec<T>();
+            codec.WriteField(ref destination, 0, typeof(T), value);
+            destination.Commit();
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<T>(Stream source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            var codec = _codecProvider.GetCodec<T>();
+            var field = reader.ReadFieldHeader();
+            return codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
         public T Deserialize<T>(ReadOnlySequence<byte> source)
         {
             using var session = _sessionPool.GetSession();
@@ -58,30 +152,226 @@ namespace Hagar
             var field = reader.ReadFieldHeader();
             return codec.ReadValue(ref reader, field);
         }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<T>(ReadOnlySpan<byte> source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            var codec = _codecProvider.GetCodec<T>();
+            var field = reader.ReadFieldHeader();
+            return codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<T>(byte[] source) => Deserialize<T>(source.AsSpan());
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<T>(ReadOnlyMemory<byte> source) => Deserialize<T>(source.Span);
+        
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <typeparam name="TInput">The reader input type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<T, TInput>(ref Reader<TInput> source)
+        {
+            var codec = _codecProvider.GetCodec<T>();
+            var field = source.ReadFieldHeader();
+            return codec.ReadValue(ref source, field);
+        }
     }
 
+    /// <summary>
+    /// Serializes and deserializes values.
+    /// </summary>
+    /// <typeparam name="T">The type of value which this instance serializes and deserializes.</typeparam>
     public sealed class Serializer<T>
     {
         private readonly IFieldCodec<T> _codec;
+        private readonly SessionPool _sessionPool;
         private readonly Type _expectedType;
 
-        public Serializer(ITypedCodecProvider codecProvider)
+        public Serializer(ITypedCodecProvider codecProvider, SessionPool sessionPool)
         {
             _expectedType = typeof(T);
             _codec = HagarGeneratedCodeHelper.UnwrapService(null, codecProvider.GetCodec<T>());
+            _sessionPool = sessionPool;
         }
 
-        public void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, in T value) where TBufferWriter : IBufferWriter<byte>
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
+        /// <typeparam name="TBufferWriter">The output buffer writer.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        public void Serialize<TBufferWriter>(in T value, ref Writer<TBufferWriter> destination) where TBufferWriter : IBufferWriter<byte>
         {
-            _codec.WriteField(ref writer, 0, _expectedType, value);
+            _codec.WriteField(ref destination, 0, _expectedType, value);
+            destination.Commit();
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <typeparam name="TInput">The reader input type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<TInput>(ref Reader<TInput> source)
+        {
+            var field = source.ReadFieldHeader();
+            return _codec.ReadValue(ref source, field);
+        }
+
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into a new array.
+        /// </summary>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="sizeHint">The estimated upper bound for the length of the serialized data.</param>
+        /// <returns>A byte array containing the serialized value.</returns>
+        public byte[] SerializeToArray(T value, int sizeHint = 0)
+        {
+            using var buffer = new PooledArrayBufferWriter(sizeHint);
+            using var session = _sessionPool.GetSession();
+            var writer = Writer.Create(buffer, session);
+            _codec.WriteField(ref writer, 0, typeof(T), value);
+            writer.Commit();
+
+            // Copy the result into a fresh array.
+            var written = buffer.WrittenSpan;
+            var result = new byte[written.Length];
+            written.CopyTo(result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        /// <remarks>This method slices the <paramref name="destination"/> to the serialized data length.</remarks>
+        public void Serialize(T value, ref Memory<byte> destination)
+        {
+            using var session = _sessionPool.GetSession();
+            var writer = Writer.Create(destination, session);
+            _codec.WriteField(ref writer, 0, typeof(T), value);
+            writer.Commit();
+            destination = destination.Slice(0, writer.Position);
+        }
+
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        /// <param name="sizeHint">The estimated upper bound for the length of the serialized data.</param>
+        /// <remarks>The destination stream will not be flushed by this method.</remarks>
+        public void Serialize(T value, Stream destination, int sizeHint = 0)
+        {
+            if (destination is MemoryStream memoryStream)
+            {
+                var buffer = new MemoryStreamBufferWriter(memoryStream);
+                using var session = _sessionPool.GetSession();
+                var writer = Writer.Create(buffer, session);
+                _codec.WriteField(ref writer, 0, typeof(T), value);
+                writer.Commit();
+            }
+            else
+            {
+                using var buffer = new PoolingStreamBufferWriter(destination, sizeHint);
+                using var session = _sessionPool.GetSession();
+                var writer = Writer.Create(buffer, session);
+                _codec.WriteField(ref writer, 0, typeof(T), value);
+                writer.Commit();
+            }
+        }
+
+        /// <summary>
+        /// Serializes the provided <paramref name="value"/> into <paramref name="destination"/>.
+        /// </summary>
+        /// <typeparam name="TBufferWriter">The output buffer writer.</typeparam>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="destination">The destination where serialized data will be written.</param>
+        public void Serialize<TBufferWriter>(T value, TBufferWriter destination) where TBufferWriter : IBufferWriter<byte>
+        {
+            using var session = _sessionPool.GetSession();
+            var writer = Writer.Create(destination, session);
+            _codec.WriteField(ref writer, 0, typeof(T), value);
             writer.Commit();
         }
 
-        public T Deserialize<TInput>(ref Reader<TInput> reader)
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(Stream source)
         {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
             var field = reader.ReadFieldHeader();
             return _codec.ReadValue(ref reader, field);
         }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(ReadOnlySequence<byte> source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            var field = reader.ReadFieldHeader();
+            return _codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(ReadOnlySpan<byte> source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            var field = reader.ReadFieldHeader();
+            return _codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(byte[] source) => Deserialize(source.AsSpan());
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(ReadOnlyMemory<byte> source) => Deserialize(source.Span);
     }
 
     public sealed class ValueSerializer<T> where T : struct

--- a/src/Hagar/Serializer.cs
+++ b/src/Hagar/Serializer.cs
@@ -26,7 +26,7 @@ namespace Hagar
         {
             var sequence = new ReadOnlySequence<byte>(source);
             using var session = _sessionPool.GetSession();
-            var reader = new Reader(sequence, session);
+            var reader = Reader.Create(sequence, session);
             var codec = _codecProvider.GetCodec<T>();
             var field = reader.ReadFieldHeader();
             return codec.ReadValue(ref reader, field);
@@ -53,7 +53,7 @@ namespace Hagar
         public T Deserialize<T>(ReadOnlySequence<byte> source)
         {
             using var session = _sessionPool.GetSession();
-            var reader = new Reader(source, session);
+            var reader = Reader.Create(source, session);
             var codec = _codecProvider.GetCodec<T>();
             var field = reader.ReadFieldHeader();
             return codec.ReadValue(ref reader, field);
@@ -77,7 +77,7 @@ namespace Hagar
             writer.Commit();
         }
 
-        public T Deserialize(ref Reader reader)
+        public T Deserialize<TInput>(ref Reader<TInput> reader)
         {
             var field = reader.ReadFieldHeader();
             return _codec.ReadValue(ref reader, field);
@@ -103,7 +103,7 @@ namespace Hagar
             writer.Commit();
         }
 
-        public void Deserialize(ref Reader reader, ref T result)
+        public void Deserialize<TInput>(ref Reader<TInput> reader, ref T result)
         {
             Field ignored = default;
             reader.ReadFieldHeader(ref ignored);

--- a/src/Hagar/Serializers/AbstractTypeSerializer.cs
+++ b/src/Hagar/Serializers/AbstractTypeSerializer.cs
@@ -34,11 +34,11 @@ namespace Hagar.Serializers
             }
         }
 
-        public TField ReadValue(ref Reader reader, Field field)
+        public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<TField>(ref reader, field);
+                return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
             }
 
             var fieldType = field.FieldType;

--- a/src/Hagar/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Hagar/Serializers/ConcreteTypeSerializer.cs
@@ -52,11 +52,11 @@ namespace Hagar.Serializers
             }
         }
 
-        TField IFieldCodec<TField>.ReadValue(ref Reader reader, Field field)
+        TField IFieldCodec<TField>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             if (field.WireType == WireType.Reference)
             {
-                return ReferenceCodec.ReadReference<TField>(ref reader, field);
+                return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
             }
 
             var fieldType = field.FieldType;

--- a/src/Hagar/Serializers/IPartialSerializer.cs
+++ b/src/Hagar/Serializers/IPartialSerializer.cs
@@ -12,6 +12,6 @@ namespace Hagar.Serializers
     public interface IPartialSerializer<T> where T : class
     {
         void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, T value) where TBufferWriter : IBufferWriter<byte>;
-        void Deserialize(ref Reader reader, T value);
+        void Deserialize<TInput>(ref Reader<TInput> reader, T value);
     }
 }

--- a/src/Hagar/Serializers/IValueSerializer.cs
+++ b/src/Hagar/Serializers/IValueSerializer.cs
@@ -12,6 +12,6 @@ namespace Hagar.Serializers
     public interface IValueSerializer<T> where T : struct
     {
         void Serialize<TBufferWriter>(ref Writer<TBufferWriter> writer, in T value) where TBufferWriter : IBufferWriter<byte>;
-        void Deserialize(ref Reader reader, ref T value);
+        void Deserialize<TInput>(ref Reader<TInput> reader, ref T value);
     }
 }

--- a/src/Hagar/Serializers/ValueSerializer.cs
+++ b/src/Hagar/Serializers/ValueSerializer.cs
@@ -28,7 +28,7 @@ namespace Hagar.Serializers
             writer.WriteEndObject();
         }
 
-        TField IFieldCodec<TField>.ReadValue(ref Reader reader, Field field)
+        TField IFieldCodec<TField>.ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             var value = default(TField);

--- a/src/Hagar/TypeSystem/RuntimeTypeNameParser.cs
+++ b/src/Hagar/TypeSystem/RuntimeTypeNameParser.cs
@@ -35,7 +35,7 @@ namespace Hagar.TypeSystem
         {
             TypeSpec result;
             char c;
-            Reader s = default;
+            BufferReader s = default;
             s.Input = input;
 
             // Read namespace and class name, including generic arity, which is a part of the class name.
@@ -129,7 +129,7 @@ namespace Hagar.TypeSystem
             return result;
         }
 
-        private static ReadOnlySpan<char> ParseTypeName(ref Reader s)
+        private static ReadOnlySpan<char> ParseTypeName(ref BufferReader s)
         {
             var start = s.Index;
             var typeName = ParseSpan(ref s, TypeNameDelimiters);
@@ -171,7 +171,7 @@ namespace Hagar.TypeSystem
             return typeName;
         }
 
-        private static int ParseArraySpecifier(ref Reader s)
+        private static int ParseArraySpecifier(ref BufferReader s)
         {
             s.ConsumeCharacter(ArrayStartIndicator);
             var dimensions = 1;
@@ -186,13 +186,13 @@ namespace Hagar.TypeSystem
             return dimensions;
         }
 
-        private static ReadOnlySpan<char> ExtractAssemblySpec(ref Reader s)
+        private static ReadOnlySpan<char> ExtractAssemblySpec(ref BufferReader s)
         {
             s.ConsumeWhitespace();
             return ParseSpan(ref s, AssemblyDelimiters);
         }
 
-        private static ReadOnlySpan<char> ParseSpan(ref Reader s, ReadOnlySpan<char> delimiters)
+        private static ReadOnlySpan<char> ParseSpan(ref BufferReader s, ReadOnlySpan<char> delimiters)
         {
             ReadOnlySpan<char> result;
             if (s.Remaining.IndexOfAny(delimiters) is int index && index > 0)
@@ -211,7 +211,7 @@ namespace Hagar.TypeSystem
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowGenericArityTooLarge(int arity) => throw new NotSupportedException($"An arity of {arity} is not supported");
 
-        private ref struct Reader
+        private ref struct BufferReader
         {
             public ReadOnlySpan<char> Input;
             public int Index;

--- a/src/Hagar/TypeSystem/TypeCodec.cs
+++ b/src/Hagar/TypeSystem/TypeCodec.cs
@@ -28,7 +28,7 @@ namespace Hagar.TypeSystem
             writer.Write(key.TypeName);
         }
 
-        public unsafe bool TryRead(ref Reader reader, out Type type)
+        public unsafe bool TryRead<TInput>(ref Reader<TInput> reader, out Type type)
         {
             var hashCode = reader.ReadInt32();
             var count = (int)reader.ReadVarUInt32();
@@ -81,7 +81,7 @@ namespace Hagar.TypeSystem
             return false;
         }
 
-        public unsafe Type Read(ref Reader reader)
+        public unsafe Type Read<TInput>(ref Reader<TInput> reader)
         {
             var hashCode = reader.ReadInt32();
             var count = (int)reader.ReadVarUInt32();
@@ -131,7 +131,7 @@ namespace Hagar.TypeSystem
             return type;
         }
 
-        private static TypeKey ReadTypeKey(ref Reader reader)
+        private static TypeKey ReadTypeKey<TInput>(ref Reader<TInput> reader)
         {
             var hashCode = reader.ReadInt32();
             var count = reader.ReadVarUInt32();

--- a/src/Hagar/Utilities/VarIntReaderExtensions.cs
+++ b/src/Hagar/Utilities/VarIntReaderExtensions.cs
@@ -7,7 +7,7 @@ namespace Hagar.Utilities
     public static class VarIntReaderExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte ReadUInt8(this ref Reader reader, WireType wireType) => wireType switch
+        public static byte ReadUInt8<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => (byte)reader.ReadVarUInt32(),
             WireType.Fixed32 => (byte)reader.ReadUInt32(),
@@ -16,7 +16,7 @@ namespace Hagar.Utilities
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ReadUInt16(this ref Reader reader, WireType wireType) => wireType switch
+        public static ushort ReadUInt16<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => (ushort)reader.ReadVarUInt32(),
             WireType.Fixed32 => (ushort)reader.ReadUInt32(),
@@ -25,7 +25,7 @@ namespace Hagar.Utilities
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ReadUInt32(this ref Reader reader, WireType wireType) => wireType switch
+        public static uint ReadUInt32<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => reader.ReadVarUInt32(),
             WireType.Fixed32 => reader.ReadUInt32(),
@@ -34,7 +34,7 @@ namespace Hagar.Utilities
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ReadUInt64(this ref Reader reader, WireType wireType) => wireType switch
+        public static ulong ReadUInt64<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => reader.ReadVarUInt64(),
             WireType.Fixed32 => reader.ReadUInt32(),
@@ -43,7 +43,7 @@ namespace Hagar.Utilities
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static sbyte ReadInt8(this ref Reader reader, WireType wireType) => wireType switch
+        public static sbyte ReadInt8<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => ZigZagDecode((byte)reader.ReadVarUInt32()),
             WireType.Fixed32 => (sbyte)reader.ReadInt32(),
@@ -52,7 +52,7 @@ namespace Hagar.Utilities
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReadInt16(this ref Reader reader, WireType wireType) => wireType switch
+        public static short ReadInt16<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => ZigZagDecode((ushort)reader.ReadVarUInt32()),
             WireType.Fixed32 => (short)reader.ReadInt32(),
@@ -62,7 +62,7 @@ namespace Hagar.Utilities
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadInt32(this ref Reader reader, WireType wireType)
+        public static int ReadInt32<TInput>(this ref Reader<TInput> reader, WireType wireType)
         {
             if (wireType == WireType.VarInt)
             {
@@ -73,7 +73,7 @@ namespace Hagar.Utilities
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static int ReadInt32Slower(this ref Reader reader, WireType wireType) => wireType switch
+        private static int ReadInt32Slower<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.Fixed32 => reader.ReadInt32(),
             WireType.Fixed64 => (int)reader.ReadInt64(),
@@ -81,7 +81,7 @@ namespace Hagar.Utilities
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long ReadInt64(this ref Reader reader, WireType wireType) => wireType switch
+        public static long ReadInt64<TInput>(this ref Reader<TInput> reader, WireType wireType) => wireType switch
         {
             WireType.VarInt => ZigZagDecode(reader.ReadVarUInt64()),
             WireType.Fixed32 => reader.ReadInt32(),

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -1,18 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.0" />
     <PackageReference Include="Hyperion" Version="0.9.16" />
     <PackageReference Include="MessagePack" Version="2.1.165" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.7" />

--- a/test/Benchmarks/Comparison/ClassDeserializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/ClassDeserializeBenchmark.cs
@@ -28,7 +28,7 @@ namespace Benchmarks.Comparison
 {
     [Trait("Category", "Benchmark")]
     [Config(typeof(BenchmarkConfig))]
-    [DisassemblyDiagnoser(maxDepth: 2, printSource: true)]
+    [DisassemblyDiagnoser(recursiveDepth: 2, printSource: true)]
     //[EtwProfiler]
     public class ClassDeserializeBenchmark
     {

--- a/test/Benchmarks/Comparison/ClassDeserializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/ClassDeserializeBenchmark.cs
@@ -128,7 +128,7 @@ namespace Benchmarks.Comparison
         public int Hagar()
         {
             Session.FullReset();
-            var reader = new Reader(HagarInput, Session);
+            var reader = Reader.Create(HagarInput, Session);
             var instance = IntClass.Create();
             _ = reader.ReadFieldHeader();
             Generated.DeserializeNew(ref reader, instance);
@@ -195,7 +195,7 @@ namespace Benchmarks.Comparison
             global::Hagar.Codecs.Int32Codec.WriteField(ref writer, 1U, Int32Type, instance.MyProperty9);
         }
 
-        public void Deserialize(ref global::Hagar.Buffers.Reader reader, global::Benchmarks.Models.IntClass instance)
+        public void Deserialize<TInput>(ref global::Hagar.Buffers.Reader<TInput> reader, global::Benchmarks.Models.IntClass instance)
         {
             uint fieldId = 0;
             while (true)
@@ -242,7 +242,7 @@ namespace Benchmarks.Comparison
                 }
             }
         }
-        public void DeserializeNew(ref global::Hagar.Buffers.Reader reader, global::Benchmarks.Models.IntClass instance)
+        public void DeserializeNew<TInput>(ref global::Hagar.Buffers.Reader<TInput> reader, global::Benchmarks.Models.IntClass instance)
         {
             int id = 0;
             Field header = default;
@@ -322,7 +322,7 @@ namespace Benchmarks.Comparison
             }
         }
 
-        private static int ReadHeader(ref Reader reader, ref Field header, int id)
+        private static int ReadHeader<TInput>(ref Reader<TInput> reader, ref Field header, int id)
         {
             reader.ReadFieldHeader(ref header);
             if (header.IsEndBaseOrEndObject)
@@ -333,7 +333,7 @@ namespace Benchmarks.Comparison
             return (int)(id + header.FieldIdDelta);
         }
 
-        private static int ReadHeaderExpectingEndBaseOrEndObject(ref Reader reader, ref Field header, int id)
+        private static int ReadHeaderExpectingEndBaseOrEndObject<TInput>(ref Reader<TInput> reader, ref Field header, int id)
         {
             reader.ReadFieldHeader(ref header);
             if (header.IsEndBaseOrEndObject)

--- a/test/Benchmarks/Comparison/ClassSerializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/ClassSerializeBenchmark.cs
@@ -86,7 +86,7 @@ namespace Benchmarks.Comparison
         {
             Session.PartialReset();
             var writer = new SingleSegmentBuffer(HagarData).CreateWriter(Session);
-            HagarSerializer.Serialize(ref writer, Input);
+            HagarSerializer.Serialize(Input, ref writer);
             return writer.Output.Length;
         }
 

--- a/test/Benchmarks/Comparison/StructDeserializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/StructDeserializeBenchmark.cs
@@ -120,7 +120,7 @@ namespace Benchmarks.Comparison
         public int Hagar()
         {
             Session.FullReset();
-            var reader = new Reader(HagarInput, Session);
+            var reader = Reader.Create(HagarInput, Session);
             IntStruct result = default;
             HagarSerializer.Deserialize(ref reader, ref result);
             return SumResult(in result);

--- a/test/Benchmarks/Comparison/StructDeserializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/StructDeserializeBenchmark.cs
@@ -26,6 +26,7 @@ namespace Benchmarks.Comparison
 {
     [Trait("Category", "Benchmark")]
     [Config(typeof(BenchmarkConfig))]
+    [DisassemblyDiagnoser(recursiveDepth: 4)]
     public class StructDeserializeBenchmark
     {
         private static readonly MemoryStream ProtoInput;

--- a/test/Benchmarks/Comparison/StructSerializeBenchmark.cs
+++ b/test/Benchmarks/Comparison/StructSerializeBenchmark.cs
@@ -83,7 +83,7 @@ namespace Benchmarks.Comparison
         {
             Session.FullReset();
             var writer = new SingleSegmentBuffer(HagarData).CreateWriter(Session);
-            HagarSerializer.Serialize(ref writer, Input);
+            HagarSerializer.Serialize(Input, ref writer);
             return writer.Output.Length;
         }
 

--- a/test/Benchmarks/ComplexTypeBenchmarks.cs
+++ b/test/Benchmarks/ComplexTypeBenchmarks.cs
@@ -95,7 +95,7 @@ namespace Benchmarks
             _hagarSerializer.Serialize(ref writer, _value);
 
             _session.FullReset();
-            var reader = new Reader(writer.Output.GetReadOnlySequence(), _session);
+            var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
             _ = _hagarSerializer.Deserialize(ref reader);
             HagarBuffer.Reset();
         }
@@ -109,7 +109,7 @@ namespace Benchmarks
             _structSerializer.Serialize(ref writer, _structValue);
 
             _session.FullReset();
-            var reader = new Reader(writer.Output.GetReadOnlySequence(), _session);
+            var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
             var result = _structSerializer.Deserialize(ref reader);
             HagarBuffer.Reset();
             return result;
@@ -132,7 +132,7 @@ namespace Benchmarks
             _hagarSerializer.Serialize(ref writer, _value);
 
             _session.FullReset();
-            var reader = new Reader(writer.Output.GetReadOnlySequence(), _session);
+            var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
             var result = _hagarSerializer.Deserialize(ref reader);
             HagarBuffer.Reset();
             return result;
@@ -170,7 +170,7 @@ namespace Benchmarks
         public object HagarDeserialize()
         {
             _session.FullReset();
-            var reader = new Reader(_hagarBytes, _session);
+            var reader = Reader.Create(_hagarBytes, _session);
             return _hagarSerializer.Deserialize(ref reader);
         }
 
@@ -182,7 +182,7 @@ namespace Benchmarks
         public int HagarReadEachByte()
         {
             var sum = 0;
-            var reader = new Reader(_hagarBytes, _session);
+            var reader = Reader.Create(_hagarBytes, _session);
             for (var i = 0; i < _readBytesLength; i++)
             {
                 sum ^= reader.ReadByte();

--- a/test/Benchmarks/ComplexTypeBenchmarks.cs
+++ b/test/Benchmarks/ComplexTypeBenchmarks.cs
@@ -74,7 +74,8 @@ namespace Benchmarks
             };
             _session = _sessionPool.GetSession();
             var writer = HagarBuffer.CreateWriter(_session);
-            _hagarSerializer.Serialize(ref writer, _value);
+
+            _hagarSerializer.Serialize(_value, ref writer);
             var bytes = new byte[writer.Output.GetMemory().Length];
             writer.Output.GetReadOnlySequence().CopyTo(bytes);
             _hagarBytes = new ReadOnlySequence<byte>(bytes);
@@ -92,7 +93,7 @@ namespace Benchmarks
         {
             var writer = HagarBuffer.CreateWriter(_session);
             _session.FullReset();
-            _hagarSerializer.Serialize(ref writer, _value);
+            _hagarSerializer.Serialize(_value, ref writer);
 
             _session.FullReset();
             var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
@@ -106,7 +107,7 @@ namespace Benchmarks
         {
             var writer = HagarBuffer.CreateWriter(_session);
             _session.FullReset();
-            _structSerializer.Serialize(ref writer, _structValue);
+            _structSerializer.Serialize(_structValue, ref writer);
 
             _session.FullReset();
             var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
@@ -129,7 +130,7 @@ namespace Benchmarks
         {
             var writer = HagarBuffer.CreateWriter(_session);
             _session.FullReset();
-            _hagarSerializer.Serialize(ref writer, _value);
+            _hagarSerializer.Serialize(_value, ref writer);
 
             _session.FullReset();
             var reader = Reader.Create(writer.Output.GetReadOnlySequence(), _session);
@@ -152,7 +153,7 @@ namespace Benchmarks
         {
             var writer = HagarBuffer.CreateWriter(_session);
             _session.FullReset();
-            _hagarSerializer.Serialize(ref writer, _value);
+            _hagarSerializer.Serialize(_value, ref writer);
             HagarBuffer.Reset();
             return _session;
         }

--- a/test/Benchmarks/Utilities/BenchmarkConfig.cs
+++ b/test/Benchmarks/Utilities/BenchmarkConfig.cs
@@ -10,8 +10,8 @@ namespace Benchmarks.Utilities
         public BenchmarkConfig()
         {
             ArtifactsPath = ".\\BenchmarkDotNet.Aritfacts." + DateTime.Now.ToString("u").Replace(' ', '_').Replace(':', '-');
-            _ = AddExporter(MarkdownExporter.GitHub);
-            _ = AddDiagnoser(MemoryDiagnoser.Default);
+            Add(MarkdownExporter.GitHub);
+            Add(MemoryDiagnoser.Default);
         }
     }
 }

--- a/test/Benchmarks/Utilities/PayloadSizeColumnAttribute.cs
+++ b/test/Benchmarks/Utilities/PayloadSizeColumnAttribute.cs
@@ -7,7 +7,8 @@ namespace Benchmarks.Utilities
     {
         public PayloadSizeColumnAttribute(string columnName = "Payload")
         {
-            Config = ManualConfig.CreateEmpty().AddColumn(
+            var config = ManualConfig.CreateEmpty();
+            config.Add(
                 new MethodResultColumn(columnName,
                     val =>
                     {
@@ -31,6 +32,7 @@ namespace Benchmarks.Utilities
 
                         return result + " B";
                     }));
+            this.Config = config;
         }
 
         public IConfig Config { get; }

--- a/test/Hagar.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Hagar.UnitTests/GeneratedSerializerTests.cs
@@ -157,7 +157,7 @@ namespace Hagar.UnitTests
                 pipe.Writer.Complete();
 
                 _ = pipe.Reader.TryRead(out var readResult);
-                var reader = new Reader(readResult.Buffer, readerSession);
+                var reader = Reader.Create(readResult.Buffer, readerSession);
 
                 var previousPos = reader.Position;
                 var initialHeader = reader.ReadFieldHeader();
@@ -186,7 +186,7 @@ namespace Hagar.UnitTests
                 pipe.Writer.Complete();
 
                 _ = pipe.Reader.TryRead(out var readResult);
-                var reader = new Reader(readResult.Buffer, readerSession);
+                var reader = Reader.Create(readResult.Buffer, readerSession);
 
                 result = serializer.Deserialize(ref reader);
                 pipe.Reader.AdvanceTo(readResult.Buffer.End);

--- a/test/Hagar.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Hagar.UnitTests/GeneratedSerializerTests.cs
@@ -180,7 +180,7 @@ namespace Hagar.UnitTests
             {
                 var writer = Writer.Create(pipe.Writer, writeSession);
                 var serializer = _serviceProvider.GetService<Serializer<object>>();
-                serializer.Serialize(ref writer, original);
+                serializer.Serialize(original, ref writer);
 
                 _ = pipe.Writer.FlushAsync().GetAwaiter().GetResult();
                 pipe.Writer.Complete();

--- a/test/Hagar.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Hagar.UnitTests/GeneratedSerializerTests.cs
@@ -145,7 +145,7 @@ namespace Hagar.UnitTests
             using (var readerSession = _sessionPool.GetSession())
             using (var writeSession = _sessionPool.GetSession())
             {
-                var writer = new Writer<PipeWriter>(pipe.Writer, writeSession);
+                var writer = Writer.Create(pipe.Writer, writeSession);
                 var codec = _codecProvider.GetCodec<T>();
                 codec.WriteField(
                     ref writer,
@@ -178,7 +178,7 @@ namespace Hagar.UnitTests
             using (var readerSession = _sessionPool.GetSession())
             using (var writeSession = _sessionPool.GetSession())
             {
-                var writer = new Writer<PipeWriter>(pipe.Writer, writeSession);
+                var writer = Writer.Create(pipe.Writer, writeSession);
                 var serializer = _serviceProvider.GetService<Serializer<object>>();
                 serializer.Serialize(ref writer, original);
 

--- a/test/Hagar.UnitTests/ISerializableTests.cs
+++ b/test/Hagar.UnitTests/ISerializableTests.cs
@@ -67,7 +67,7 @@ namespace Hagar.UnitTests
             using (var session = _sessionPool.GetSession())
             {
                 _ = pipe.Reader.TryRead(out var readResult);
-                var reader = new Reader(readResult.Buffer, session);
+                var reader = Reader.Create(readResult.Buffer, session);
                 var result = _serializer.Deserialize(ref reader);
                 pipe.Reader.AdvanceTo(readResult.Buffer.End);
                 pipe.Reader.Complete();

--- a/test/Hagar.UnitTests/ISerializableTests.cs
+++ b/test/Hagar.UnitTests/ISerializableTests.cs
@@ -58,7 +58,7 @@ namespace Hagar.UnitTests
 
             using (var session = _sessionPool.GetSession())
             {
-                var writer = new Writer<PipeWriter>(pipe.Writer, session);
+                var writer = Writer.Create(pipe.Writer, session);
                 _serializer.Serialize(ref writer, expected);
                 _ = pipe.Writer.FlushAsync().GetAwaiter().GetResult();
                 pipe.Writer.Complete();

--- a/test/Hagar.UnitTests/ISerializableTests.cs
+++ b/test/Hagar.UnitTests/ISerializableTests.cs
@@ -59,7 +59,7 @@ namespace Hagar.UnitTests
             using (var session = _sessionPool.GetSession())
             {
                 var writer = Writer.Create(pipe.Writer, session);
-                _serializer.Serialize(ref writer, expected);
+                _serializer.Serialize(expected, ref writer);
                 _ = pipe.Writer.FlushAsync().GetAwaiter().GetResult();
                 pipe.Writer.Complete();
             }

--- a/test/Hagar.UnitTests/ManualVersionToleranceTests.cs
+++ b/test/Hagar.UnitTests/ManualVersionToleranceTests.cs
@@ -134,7 +134,7 @@ namespace Hagar.UnitTests
             pipe.Writer.Complete();
             _ = pipe.Reader.TryRead(out var readResult);
             using var readerSesssion = GetSession();
-            var reader = new Reader(readResult.Buffer, readerSesssion);
+            var reader = Reader.Create(readResult.Buffer, readerSesssion);
             var initialHeader = reader.ReadFieldHeader();
 
             _log.WriteLine("Header:");
@@ -168,7 +168,7 @@ namespace Hagar.UnitTests
             pipe.Writer.Complete();
             _ = pipe.Reader.TryRead(out var readResult);
             using var readerSession = GetSession();
-            var reader = new Reader(readResult.Buffer, readerSession);
+            var reader = Reader.Create(readResult.Buffer, readerSession);
             var initialHeader = reader.ReadFieldHeader();
             var skipCodec = new SkipFieldCodec();
             _ = skipCodec.ReadValue(ref reader, initialHeader);
@@ -295,7 +295,7 @@ namespace Hagar.UnitTests
                 writer.WriteFieldHeader(session, 1020, typeof(object), typeof(Program), WireType.Reference);*/
             }
 
-            public void Deserialize(ref Reader reader, SubType obj)
+            public void Deserialize<TInput>(ref Reader<TInput> reader, SubType obj)
             {
                 uint fieldId = 0;
                 _baseTypeSerializer.Deserialize(ref reader, obj);
@@ -335,7 +335,7 @@ namespace Hagar.UnitTests
                 StringCodec.WriteField(ref writer, 234, typeof(string), obj.AddedLaterString);
             }
 
-            public void Deserialize(ref Reader reader, BaseType obj)
+            public void Deserialize<TInput>(ref Reader<TInput> reader, BaseType obj)
             {
                 uint fieldId = 0;
                 while (true)

--- a/test/Hagar.UnitTests/ManualVersionToleranceTests.cs
+++ b/test/Hagar.UnitTests/ManualVersionToleranceTests.cs
@@ -122,7 +122,7 @@ namespace Hagar.UnitTests
         {
             using var writerSession = GetSession();
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, writerSession);
+            var writer = Writer.Create(pipe.Writer, writerSession);
 
             _serializer.WriteField(ref writer, 0, typeof(SubType), expected);
             writer.Commit();
@@ -159,7 +159,7 @@ namespace Hagar.UnitTests
         {
             using var writerSession = GetSession();
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, writerSession);
+            var writer = Writer.Create(pipe.Writer, writerSession);
 
             _serializer.WriteField(ref writer, 0, typeof(SubType), expected);
             writer.Commit();

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -112,7 +112,7 @@ namespace TestApp
 
             var writeSession = sessionPool.GetSession();
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, writeSession);
+            var writer = Writer.Create(pipe.Writer, writeSession);
             codec.WriteField(ref writer,
                              0,
                              typeof(SomeClassWithSerialzers),
@@ -193,7 +193,7 @@ namespace TestApp
         {
             using var writerSession = getSession();
             var pipe = new Pipe();
-            var writer = new Writer<PipeWriter>(pipe.Writer, writerSession);
+            var writer = Writer.Create(pipe.Writer, writerSession);
 
             serializer.WriteField(ref writer, 0, typeof(T), expected);
             writer.Commit();

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -123,7 +123,7 @@ namespace TestApp
             _ = pipe.Reader.TryRead(out var readResult);
 
             using var readerSession = sessionPool.GetSession();
-            var reader = new Reader(readResult.Buffer, readerSession);
+            var reader = Reader.Create(readResult.Buffer, readerSession);
             var initialHeader = reader.ReadFieldHeader();
             var result = codec.ReadValue(ref reader, initialHeader);
             Console.WriteLine(result);
@@ -205,7 +205,7 @@ namespace TestApp
             pipe.Writer.Complete();
             _ = pipe.Reader.TryRead(out var readResult);
             using var readerSesssion = getSession();
-            var reader = new Reader(readResult.Buffer, readerSesssion);
+            var reader = Reader.Create(readResult.Buffer, readerSesssion);
             var initialHeader = reader.ReadFieldHeader();
 
             Console.WriteLine("Header:");

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds new types, `Serializer` and `Serializer<T>`. The former is able to serialize any supported type, and the latter serializes only types which are assignable to `T`.

In addition, this PR adds support for serializing/deserializing to/from:
* `Stream` (with specialization for `MemoryStream`)
* `byte[]`
* `Memory<byte>`/`Span<byte>`

The intention is to create a more user-friendly API while not sacrificing performance