### PR TITLE
Support specifying type ids and aliases via attributes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Reuben Bond</Authors>
     <Product>Hagar</Product>
-    <VersionPrefix>0.4.3</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <Copyright>Copyright © Reuben Bond 2020</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ReubenBond/Hagar</PackageProjectUrl>

--- a/src/Hagar.Abstractions/Annotations.cs
+++ b/src/Hagar.Abstractions/Annotations.cs
@@ -37,6 +37,36 @@ namespace Hagar
         public ushort Id { get; }
     }
 
+    [AttributeUsage(
+        AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Enum
+        | AttributeTargets.Method)]
+    public sealed class WellKnownIdAttribute : Attribute
+    {
+        public WellKnownIdAttribute(uint id)
+        {
+            Id = id;
+        }
+
+        public uint Id { get; }
+    }
+
+    [AttributeUsage(
+        AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Enum
+        | AttributeTargets.Method)]
+    public sealed class WellKnownAliasAttribute : Attribute
+    {
+        public WellKnownAliasAttribute(string alias)
+        {
+            Alias = alias;
+        }
+
+        public string Alias { get; }
+    }
+
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
     public sealed class RegisterSerializerAttribute : Attribute
     {

--- a/src/Hagar.CodeGenerator/LibraryTypes.cs
+++ b/src/Hagar.CodeGenerator/LibraryTypes.cs
@@ -26,6 +26,8 @@ namespace Hagar.CodeGenerator
                 IActivator_1 = Type("Hagar.Activators.IActivator`1"),
                 IBufferWriter = Type("System.Buffers.IBufferWriter`1"),
                 IdAttributeTypes = options.IdAttributeTypes.Select(Type).ToList(),
+                WellKnownAliasAttribute = Type("Hagar.WellKnownAliasAttribute"), 
+                WellKnownIdAttribute = Type("Hagar.WellKnownIdAttribute"), 
                 IInvokable = Type("Hagar.Invocation.IInvokable"),
                 RegisterSerializerAttribute = Type("Hagar.RegisterSerializerAttribute"),
                 RegisterActivatorAttribute = Type("Hagar.RegisterActivatorAttribute"),
@@ -139,6 +141,8 @@ namespace Hagar.CodeGenerator
         public INamedTypeSymbol Void { get; private set; }
         public INamedTypeSymbol Writer { get; private set; }
         public List<INamedTypeSymbol> IdAttributeTypes { get; private set; }
+        public INamedTypeSymbol WellKnownAliasAttribute { get; private set; }
+        public INamedTypeSymbol WellKnownIdAttribute { get; private set; }
         public List<StaticCodecDescription> StaticCodecs { get; private set; }
         public INamedTypeSymbol RegisterSerializerAttribute { get; private set; }
         public INamedTypeSymbol RegisterActivatorAttribute { get; private set; }

--- a/src/Hagar.CodeGenerator/MetadataGenerator.cs
+++ b/src/Hagar.CodeGenerator/MetadataGenerator.cs
@@ -69,6 +69,36 @@ namespace Hagar.CodeGenerator
                                         Argument(TypeOfExpression(type.ToOpenTypeSyntax()))))))
                 ));
 
+            var addWellKnownTypeIdMethod = configParam.Member("WellKnownTypeIds").Member("Add");
+            body.AddRange(
+                metadataModel.WellKnownTypeIds.Select(
+                    type =>
+                        (StatementSyntax)ExpressionStatement(
+                            InvocationExpression(
+                                addWellKnownTypeIdMethod,
+                                ArgumentList(SeparatedList(
+                                    new[]
+                                    {
+                                        Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Id))),
+                                        Argument(TypeOfExpression(type.Type.ToOpenTypeSyntax()))
+                                    }))))
+                ));
+            
+            var addTypeAliasMethod = configParam.Member("WellKnownTypeAliases").Member("Add");
+            body.AddRange(
+                metadataModel.TypeAliases.Select(
+                    type =>
+                        (StatementSyntax)ExpressionStatement(
+                            InvocationExpression(
+                                addTypeAliasMethod,
+                                ArgumentList(SeparatedList(
+                                    new[]
+                                    {
+                                        Argument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(type.Alias))),
+                                        Argument(TypeOfExpression(type.Type.ToOpenTypeSyntax()))
+                                    }))))
+                ));
+
             var configType = libraryTypes.SerializerConfiguration;
             var configureMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), "Configure")
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))

--- a/src/Hagar.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Hagar.CodeGenerator/Model/MetadataModel.cs
@@ -16,5 +16,7 @@ namespace Hagar.CodeGenerator
             new List<ISerializableTypeDescription>(1024);
         public List<INamedTypeSymbol> DetectedSerializers { get; } = new List<INamedTypeSymbol>();
         public List<INamedTypeSymbol> DetectedActivators { get; } = new List<INamedTypeSymbol>();
+        public List<(INamedTypeSymbol Type, string Alias)> TypeAliases { get; } = new List<(INamedTypeSymbol, string)>(1024);
+        public List<(INamedTypeSymbol Type, uint Id)> WellKnownTypeIds { get; } = new List<(INamedTypeSymbol, uint)>(1024);
     }
 }

--- a/src/Hagar/Configuration/DefaultTypeConfiguration.cs
+++ b/src/Hagar/Configuration/DefaultTypeConfiguration.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace Hagar.Configuration
 {
-    internal class DefaultTypeConfiguration : IConfigurationProvider<TypeConfiguration>
+    internal class DefaultTypeConfiguration : IConfigurationProvider<SerializerConfiguration>
     {
-        public void Configure(TypeConfiguration options)
+        public void Configure(SerializerConfiguration options)
         {
-            var wellKnownTypes = options.WellKnownTypes;
+            var wellKnownTypes = options.WellKnownTypeIds;
             wellKnownTypes[0] = typeof(void); // Represents the type of null
             wellKnownTypes[1] = typeof(int);
             wellKnownTypes[2] = typeof(string);

--- a/src/Hagar/Configuration/SerializerConfiguration.cs
+++ b/src/Hagar/Configuration/SerializerConfiguration.cs
@@ -12,10 +12,9 @@ namespace Hagar.Configuration
         public HashSet<Type> Serializers { get; } = new HashSet<Type>();
 
         public HashSet<Type> InterfaceProxies { get; } = new HashSet<Type>();
-    }
 
-    public sealed class TypeConfiguration
-    {
-        public Dictionary<uint, Type> WellKnownTypes { get; } = new Dictionary<uint, Type>();
+        public Dictionary<uint, Type> WellKnownTypeIds { get; } = new Dictionary<uint, Type>();
+
+        public Dictionary<string, Type> WellKnownTypeAliases { get; } = new Dictionary<string, Type>();
     }
 }

--- a/src/Hagar/Hagar.csproj
+++ b/src/Hagar/Hagar.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />

--- a/src/Hagar/Hosting/ServiceProviderExtensions.cs
+++ b/src/Hagar/Hosting/ServiceProviderExtensions.cs
@@ -24,7 +24,7 @@ namespace Hagar
                 context = new HagarConfigurationContext(services);
                 _ = context.Builder.AddAssembly(typeof(ServiceProviderExtensions).Assembly);
                 services.Add(context.CreateServiceDescriptor());
-                _ = services.AddSingleton<IConfigurationProvider<TypeConfiguration>, DefaultTypeConfiguration>();
+                _ = services.AddSingleton<IConfigurationProvider<SerializerConfiguration>, DefaultTypeConfiguration>();
                 _ = services.AddSingleton<TypeConverter>();
                 services.TryAddSingleton(typeof(ListActivator<>));
                 services.TryAddSingleton(typeof(DictionaryActivator<,>));

--- a/src/Hagar/Session/WellKnownTypeCollection.cs
+++ b/src/Hagar/Session/WellKnownTypeCollection.cs
@@ -7,7 +7,7 @@ namespace Hagar.Session
     public sealed class WellKnownTypeCollection
     {
         private readonly Dictionary<uint, Type> _wellKnownTypes;
-        private readonly Dictionary<Type, uint> _wellKnownTypeToIdMap; 
+        private readonly Dictionary<Type, uint> _wellKnownTypeToIdMap;
 
         public WellKnownTypeCollection(IConfiguration<SerializerConfiguration> config)
         {

--- a/src/Hagar/Session/WellKnownTypeCollection.cs
+++ b/src/Hagar/Session/WellKnownTypeCollection.cs
@@ -7,11 +7,12 @@ namespace Hagar.Session
     public sealed class WellKnownTypeCollection
     {
         private readonly Dictionary<uint, Type> _wellKnownTypes;
-        private readonly Dictionary<Type, uint> _wellKnownTypeToIdMap = new Dictionary<Type, uint>();
+        private readonly Dictionary<Type, uint> _wellKnownTypeToIdMap; 
 
-        public WellKnownTypeCollection(IConfiguration<TypeConfiguration> typeConfiguration)
+        public WellKnownTypeCollection(IConfiguration<SerializerConfiguration> config)
         {
-            _wellKnownTypes = typeConfiguration?.Value.WellKnownTypes ?? throw new ArgumentNullException(nameof(typeConfiguration));
+            _wellKnownTypes = config?.Value.WellKnownTypeIds ?? throw new ArgumentNullException(nameof(config));
+            _wellKnownTypeToIdMap = new Dictionary<Type, uint>();
             foreach (var item in _wellKnownTypes)
             {
                 _wellKnownTypeToIdMap[item.Value] = item.Key;

--- a/src/Hagar/TypeSystem/QualifiedType.cs
+++ b/src/Hagar/TypeSystem/QualifiedType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Hagar.TypeSystem
 {
     public readonly struct QualifiedType
@@ -8,15 +10,19 @@ namespace Hagar.TypeSystem
             Type = type;
         }
 
+        public string Assembly { get; }
+        public string Type { get; }
+
         public void Deconstruct(out string assembly, out string type)
         {
             assembly = Assembly;
             type = Type;
         }
 
-        public static implicit operator QualifiedType((string Assembly, string Type) args) => new QualifiedType(args.Assembly, args.Type);
+        public override bool Equals(object obj) => obj is QualifiedType type && string.Equals(Assembly, type.Assembly, StringComparison.Ordinal) && string.Equals(Type, type.Type, StringComparison.Ordinal);
 
-        public string Assembly { get; }
-        public string Type { get; }
+        public override int GetHashCode() => HashCode.Combine(Assembly, Type);
+
+        public static implicit operator QualifiedType((string Assembly, string Type) args) => new QualifiedType(args.Assembly, args.Type);
     }
 }

--- a/test/Hagar.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Hagar.UnitTests/GeneratedSerializerTests.cs
@@ -2,6 +2,7 @@ using Hagar.Buffers;
 using Hagar.Codecs;
 using Hagar.Serializers;
 using Hagar.Session;
+using Hagar.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using System;
@@ -229,6 +230,7 @@ namespace Hagar.UnitTests
                 pipe.Writer.Complete();
 
                 _ = pipe.Reader.TryRead(out var readResult);
+
                 var reader = Reader.Create(readResult.Buffer, readerSession);
 
                 result = serializer.Deserialize(ref reader);

--- a/test/Hagar.UnitTests/GeneratedSerializerTests.cs
+++ b/test/Hagar.UnitTests/GeneratedSerializerTests.cs
@@ -43,7 +43,7 @@ namespace Hagar.UnitTests
         public void GeneratedSerializersRoundTripThroughSerializer()
         {
             var original = new SomeClassWithSerializers { IntField = 2, IntProperty = 30 };
-            var result = (SomeClassWithSerializers)RoundTripThroughUntypedSerializer(original);
+            var result = (SomeClassWithSerializers)RoundTripThroughUntypedSerializer(original, out _);
 
             Assert.Equal(original.IntField, result.IntField);
             Assert.Equal(original.IntProperty, result.IntProperty);
@@ -53,7 +53,7 @@ namespace Hagar.UnitTests
         public void GeneratedSerializersRoundTripThroughSerializer_ImmutableClass()
         {
             var original = new ImmutableClass(30, 2, 88, 99);
-            var result = (ImmutableClass)RoundTripThroughUntypedSerializer(original);
+            var result = (ImmutableClass)RoundTripThroughUntypedSerializer(original, out _);
 
             Assert.Equal(original.GetIntField(), result.GetIntField());
             Assert.Equal(original.IntProperty, result.IntProperty);
@@ -65,7 +65,7 @@ namespace Hagar.UnitTests
         public void GeneratedSerializersRoundTripThroughSerializer_ImmutableStruct()
         {
             var original = new ImmutableStruct(30, 2);
-            var result = (ImmutableStruct)RoundTripThroughUntypedSerializer(original);
+            var result = (ImmutableStruct)RoundTripThroughUntypedSerializer(original, out _);
 
             Assert.Equal(original.GetIntField(), result.GetIntField());
             Assert.Equal(original.IntProperty, result.IntProperty);
@@ -89,17 +89,33 @@ namespace Hagar.UnitTests
                 ArrayField = new[] { "a", "bb", "ccc" },
                 Field = Guid.NewGuid().ToString("N")
             };
-            var result = (GenericPoco<string>)RoundTripThroughUntypedSerializer(original);
+            var result = (GenericPoco<string>)RoundTripThroughUntypedSerializer(original, out var formattedBitStream);
 
             Assert.Equal(original.ArrayField, result.ArrayField);
             Assert.Equal(original.Field, result.Field);
+            Assert.Contains("gpoco`1", formattedBitStream);
+        }
+
+        [Fact]
+        public void NestedGenericPocoWithTypeAlias()
+        {
+            var original = new GenericPoco<GenericPoco<string>>
+            {
+                Field = new GenericPoco<string>
+                {
+                    Field = Guid.NewGuid().ToString("N")
+                }
+            };
+
+            RoundTripThroughUntypedSerializer(original, out var formattedBitStream);
+            Assert.Contains("gpoco`1[[gpoco`1[[string]]]]", formattedBitStream);
         }
 
         [Fact]
         public void ArraysAreSupported()
         {
             var original = new[] { "a", "bb", "ccc" };
-            var result = (string[])RoundTripThroughUntypedSerializer(original);
+            var result = (string[])RoundTripThroughUntypedSerializer(original, out _);
 
             Assert.Equal(original, result);
         }
@@ -116,7 +132,7 @@ namespace Hagar.UnitTests
                 Dim32 = new int[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,] { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { { 809 } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } },
                 Jagged = new int[][] { new int[] { 909 } }
             };
-            var result = (ArrayPoco<int>)RoundTripThroughUntypedSerializer(original);
+            var result = (ArrayPoco<int>)RoundTripThroughUntypedSerializer(original, out _);
 
             Assert.Equal(JsonConvert.SerializeObject(original), JsonConvert.SerializeObject(result));
         }
@@ -125,7 +141,7 @@ namespace Hagar.UnitTests
         public void MultiDimensionalArraysAreSupported()
         {
             var array2d = new string[,] { { "1", "2", "3" }, { "4", "5", "6" }, { "7", "8", "9" } };
-            var result2d = (string[,])RoundTripThroughUntypedSerializer(array2d);
+            var result2d = (string[,])RoundTripThroughUntypedSerializer(array2d, out _);
 
             Assert.Equal(array2d, result2d);
             var array3d = new string[,,]
@@ -134,7 +150,7 @@ namespace Hagar.UnitTests
                 { { "g", "r", "g" }, { "1", "3", "a" }, { "l", "k", "a" } },
                 { { "z", "b", "g" }, { "5", "7", "a" }, { "5", "n", "0" } }
             };
-            var result3d = (string[,,])RoundTripThroughUntypedSerializer(array3d);
+            var result3d = (string[,,])RoundTripThroughUntypedSerializer(array3d, out _);
 
             Assert.Equal(array3d, result3d);
         }
@@ -215,7 +231,7 @@ namespace Hagar.UnitTests
             return result;
         }
 
-        private object RoundTripThroughUntypedSerializer(object original)
+        private object RoundTripThroughUntypedSerializer(object original, out string formattedBitStream)
         {
             var pipe = new Pipe();
             object result;
@@ -230,6 +246,9 @@ namespace Hagar.UnitTests
                 pipe.Writer.Complete();
 
                 _ = pipe.Reader.TryRead(out var readResult);
+
+                using var analyzerSession = _sessionPool.GetSession();
+                formattedBitStream = BitStreamFormatter.Format(readResult.Buffer, analyzerSession);
 
                 var reader = Reader.Create(readResult.Buffer, readerSession);
 

--- a/test/Hagar.UnitTests/Models.cs
+++ b/test/Hagar.UnitTests/Models.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 namespace Hagar.UnitTests
 {
     [GenerateSerializer]
+    [WellKnownId(3201)]
     public class SomeClassWithSerializers
     {
         [Id(0)]
@@ -19,6 +20,7 @@ namespace Hagar.UnitTests
     }
 
     [GenerateSerializer]
+    [WellKnownAlias("sercla1")]
     public class SerializableClassWithCompiledBase : List<int>
     {
         [Id(0)]

--- a/test/Hagar.UnitTests/Models.cs
+++ b/test/Hagar.UnitTests/Models.cs
@@ -28,6 +28,7 @@ namespace Hagar.UnitTests
     }
 
     [GenerateSerializer]
+    [WellKnownAlias("gpoco`1")]
     public class GenericPoco<T>
     {
         [Id(0)]

--- a/test/Hagar.UnitTests/PolymorphismTests.cs
+++ b/test/Hagar.UnitTests/PolymorphismTests.cs
@@ -16,18 +16,18 @@ namespace Hagar.UnitTests
                 {
                     hagar.AddAssembly(typeof(PolymorphismTests).Assembly);
                 })
-                .AddSingleton<IConfigurationProvider<TypeConfiguration>, TypeConfigurationProvider>()
+                .AddSingleton<IConfigurationProvider<SerializerConfiguration>, TypeConfigurationProvider>()
                 .BuildServiceProvider();
         }
 
-        private class TypeConfigurationProvider : IConfigurationProvider<TypeConfiguration>
+        private class TypeConfigurationProvider : IConfigurationProvider<SerializerConfiguration>
         {
-            public void Configure(TypeConfiguration configuration)
+            public void Configure(SerializerConfiguration configuration)
             {
-                configuration.WellKnownTypes[1000] = typeof(SomeBaseClass);
-                configuration.WellKnownTypes[1001] = typeof(SomeSubClass);
-                configuration.WellKnownTypes[1002] = typeof(OtherSubClass);
-                configuration.WellKnownTypes[1003] = typeof(SomeSubClassChild);
+                configuration.WellKnownTypeIds[1000] = typeof(SomeBaseClass);
+                configuration.WellKnownTypeIds[1001] = typeof(SomeSubClass);
+                configuration.WellKnownTypeIds[1002] = typeof(OtherSubClass);
+                configuration.WellKnownTypeIds[1003] = typeof(SomeSubClassChild);
             }
         }
 


### PR DESCRIPTION
This PR enables support for defining WellKnownTypeIds and WellKnownTypeAliases via attributes on said types, as well as via programmatic configuration (attributes are recommended, since they are visible to codegen).

Use `[WellKnownTypeId(id)]` and `[WellKnownTypeAlias("myalias")]`. Note that for type aliases on generic types, the generic arity must be specified, eg `"gpoco`1"` for a type with one parameter.

Closes #47