### PR TITLE
Generate IFieldCodecs for all classes/structs

### DIFF
--- a/src/Hagar.Abstractions/Annotations.cs
+++ b/src/Hagar.Abstractions/Annotations.cs
@@ -76,4 +76,9 @@ namespace Hagar
     public sealed class RegisterActivatorAttribute : Attribute
     {
     }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public sealed class UseActivatorAttribute : Attribute
+    {
+    }
 }

--- a/src/Hagar.CodeGenerator/CodeGenerator.cs
+++ b/src/Hagar.CodeGenerator/CodeGenerator.cs
@@ -151,7 +151,7 @@ namespace Hagar.CodeGenerator
 
                     if (ShouldGenerateSerializer(symbol))
                     {
-                        var typeDescription = new SerializableTypeDescription(semanticModel, symbol, GetDataMembers(symbol));
+                        var typeDescription = new SerializableTypeDescription(semanticModel, symbol, GetDataMembers(symbol), _libraryTypes);
                         metadataModel.SerializableTypes.Add(typeDescription);
                     }
 

--- a/src/Hagar.CodeGenerator/InvokableGenerator.cs
+++ b/src/Hagar.CodeGenerator/InvokableGenerator.cs
@@ -449,6 +449,7 @@ namespace Hagar.CodeGenerator
             public INamedTypeSymbol BaseType => throw new NotImplementedException();
             public string Name { get; }
             public bool IsValueType => false;
+            public bool IsSealedType => true;
             public bool IsEnumType => false;
             public bool IsGenericType => _methodDescription.Method.IsGenericMethod;
             public ImmutableArray<ITypeParameterSymbol> TypeParameters { get; }
@@ -457,6 +458,8 @@ namespace Hagar.CodeGenerator
             public SemanticModel SemanticModel => InterfaceDescription.SemanticModel;
 
             public bool IsEmptyConstructable => true;
+
+            public bool UseActivator => true; 
 
             public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => InvocationExpression(libraryTypes.InvokablePool.ToTypeSyntax().Member("Get", TypeSyntax))
                 .WithArgumentList(ArgumentList(SeparatedList<ArgumentSyntax>()));

--- a/src/Hagar.CodeGenerator/LibraryTypes.cs
+++ b/src/Hagar.CodeGenerator/LibraryTypes.cs
@@ -18,6 +18,7 @@ namespace Hagar.CodeGenerator
                 Byte = compilation.GetSpecialType(SpecialType.System_Byte),
                 ConfigurationProvider = Type("Hagar.Configuration.IConfigurationProvider`1"),
                 Field = Type("Hagar.WireProtocol.Field"),
+                WireType = Type("Hagar.WireProtocol.WireType"),
                 FieldCodec = Type("Hagar.Codecs.IFieldCodec"),
                 FieldCodec_1 = Type("Hagar.Codecs.IFieldCodec`1"),
                 Func_2 = Type("System.Func`2"),
@@ -31,6 +32,7 @@ namespace Hagar.CodeGenerator
                 IInvokable = Type("Hagar.Invocation.IInvokable"),
                 RegisterSerializerAttribute = Type("Hagar.RegisterSerializerAttribute"),
                 RegisterActivatorAttribute = Type("Hagar.RegisterActivatorAttribute"),
+                UseActivatorAttribute = Type("Hagar.UseActivatorAttribute"),
                 Int32 = compilation.GetSpecialType(SpecialType.System_Int32),
                 UInt32 = compilation.GetSpecialType(SpecialType.System_UInt32),
                 InvalidOperationException = Type("System.InvalidOperationException"),
@@ -103,6 +105,7 @@ namespace Hagar.CodeGenerator
         public INamedTypeSymbol Byte { get; private set; }
         public INamedTypeSymbol ConfigurationProvider { get; private set; }
         public INamedTypeSymbol Field { get; private set; }
+        public INamedTypeSymbol WireType { get; private set; }
         public INamedTypeSymbol FieldCodec_1 { get; private set; }
         public INamedTypeSymbol FieldCodec { get; private set; }
         public INamedTypeSymbol Func_2 { get; private set; }
@@ -146,5 +149,6 @@ namespace Hagar.CodeGenerator
         public List<StaticCodecDescription> StaticCodecs { get; private set; }
         public INamedTypeSymbol RegisterSerializerAttribute { get; private set; }
         public INamedTypeSymbol RegisterActivatorAttribute { get; private set; }
+        public INamedTypeSymbol UseActivatorAttribute { get; private set; }
     }
 }

--- a/src/Hagar.CodeGenerator/Model/ISerializableTypeDescription.cs
+++ b/src/Hagar.CodeGenerator/Model/ISerializableTypeDescription.cs
@@ -13,11 +13,13 @@ namespace Hagar.CodeGenerator
         INamedTypeSymbol BaseType { get; }
         string Name { get; }
         bool IsValueType { get; }
+        bool IsSealedType { get; }
         bool IsEnumType { get; }
         bool IsGenericType { get; }
         ImmutableArray<ITypeParameterSymbol> TypeParameters { get; }
         List<IMemberDescription> Members { get; }
         SemanticModel SemanticModel { get; }
+        bool UseActivator { get; }
         bool IsEmptyConstructable { get; }
         ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes);
     }

--- a/src/Hagar.CodeGenerator/Model/SerializableTypeDescription.cs
+++ b/src/Hagar.CodeGenerator/Model/SerializableTypeDescription.cs
@@ -10,11 +10,14 @@ namespace Hagar.CodeGenerator
 {
     internal class SerializableTypeDescription : ISerializableTypeDescription
     {
-        public SerializableTypeDescription(SemanticModel semanticModel, INamedTypeSymbol type, IEnumerable<IMemberDescription> members)
+        private readonly LibraryTypes _libraryTypes;
+
+        public SerializableTypeDescription(SemanticModel semanticModel, INamedTypeSymbol type, IEnumerable<IMemberDescription> members, LibraryTypes libraryTypes)
         {
             Type = type;
             Members = members.ToList();
             SemanticModel = semanticModel;
+            _libraryTypes = libraryTypes;
         }
 
         private INamedTypeSymbol Type { get; }
@@ -31,6 +34,7 @@ namespace Hagar.CodeGenerator
         public string Name => Type.Name;
 
         public bool IsValueType => Type.IsValueType;
+        public bool IsSealedType => Type.IsSealed;
         public bool IsEnumType => Type.EnumUnderlyingType != null;
 
         public bool IsGenericType => Type.IsGenericType;
@@ -66,6 +70,8 @@ namespace Hagar.CodeGenerator
                 return false;
             }
         }
+
+        public bool UseActivator => Type.HasAttribute(_libraryTypes.UseActivatorAttribute) || !IsEmptyConstructable;
 
         public ExpressionSyntax GetObjectCreationExpression(LibraryTypes libraryTypes) => InvocationExpression(ObjectCreationExpression(TypeSyntax));
     }

--- a/src/Hagar/GeneratedCodeHelpers/HagarGeneratedCodeHelper.cs
+++ b/src/Hagar/GeneratedCodeHelpers/HagarGeneratedCodeHelper.cs
@@ -3,6 +3,7 @@ using Hagar.Codecs;
 using Hagar.Serializers;
 using Hagar.WireProtocol;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -127,6 +128,20 @@ namespace Hagar.GeneratedCodeHelpers
             }
 
             return (int)(id + header.FieldIdDelta);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void SerializeUnexpectedType<TBufferWriter, TField>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
+        {
+            var specificSerializer = writer.Session.CodecProvider.GetCodec(value.GetType());
+            specificSerializer.WriteField(ref writer, fieldIdDelta, expectedType, value);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static TField DeserializeUnexpectedType<TInput, TField>(ref Reader<TInput> reader, Field field)
+        {
+            var specificSerializer = reader.Session.CodecProvider.GetCodec(field.FieldType);
+            return (TField)specificSerializer.ReadValue(ref reader, field);
         }
     }
 }

--- a/test/Benchmarks/Models/IntClass.cs
+++ b/test/Benchmarks/Models/IntClass.cs
@@ -9,7 +9,7 @@ namespace Benchmarks.Models
     [GenerateSerializer]
     [ProtoContract]
     [MessagePackObject]
-    public class IntClass
+    public sealed class IntClass
     {
         public static IntClass Create()
         {

--- a/test/Hagar.UnitTests/Hagar.UnitTests.csproj
+++ b/test/Hagar.UnitTests/Hagar.UnitTests.csproj
@@ -5,7 +5,8 @@
     <TargetFrameworks Condition=" '$(TestTargetFrameworks)' != '' ">$(TestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net5.0;net48</TargetFrameworks>
-	<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Rather than only generating `IValueSerializer<T>`/`IPartialSerializer<T>` types, the code generator will now generate `IFieldCodec<T>` for all types (classes, structs, and we were already doing enums).

The benefit is improved performance through less indirection/overhead and better JITtability of the code.

ClassSerializeBenchmark:
```
|            Method |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated | Payload |
|------------------ |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|--------:|
|             Hagar |    62.88 ns |  0.164 ns |  0.145 ns |  1.00 |    0.00 |      - |     - |     - |         - |    20 B |
|         Hagar Old |    73.08 ns |  0.448 ns |  0.397 ns |  1.16 |       - |      - |     - |     - |         - |    20 B |
|          Utf8Json |   159.45 ns |  0.452 ns |  0.401 ns |  2.52 |    0.01 |      - |     - |     - |         - |   154 B |
|    SystemTextJson |   515.95 ns |  3.486 ns |  3.261 ns |  8.21 |    0.06 |      - |     - |     - |         - |   154 B |
| MessagePackCSharp |   174.01 ns |  0.794 ns |  0.704 ns |  2.77 |    0.01 | 0.0048 |     - |     - |      40 B |    10 B |
|       ProtobufNet |   291.62 ns |  3.460 ns |  3.236 ns |  4.64 |    0.05 |      - |     - |     - |         - |    18 B |
|          Hyperion |   119.50 ns |  0.869 ns |  0.813 ns |  1.90 |    0.01 |      - |     - |     - |         - |    39 B |
|    NewtonsoftJson | 1,884.85 ns | 11.423 ns | 10.685 ns | 29.97 |    0.18 | 0.2403 |     - |     - |    2024 B |   154 B |
|          SpanJson |   136.87 ns |  1.013 ns |  0.898 ns |  2.18 |    0.02 | 0.0219 |     - |     - |     184 B |   154 B |
```

ClassDeserializeBenchmark:
```
|            Method |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|             Hagar |    88.98 ns |  0.223 ns |  0.186 ns |  1.00 |    0.00 | 0.0067 |     - |     - |      56 B |
|         Hagar Old |   113.80 ns |   1.65 ns |   1.54 ns |  1.28 |       - | 0.0067 |     - |     - |      56 B |
|          Utf8Json |   505.42 ns |  4.084 ns |  3.820 ns |  5.69 |    0.05 | 0.0067 |     - |     - |      56 B |
|    SystemTextJson | 1,131.63 ns |  5.822 ns |  5.446 ns | 12.73 |    0.06 | 0.0057 |     - |     - |      56 B |
| MessagePackCSharp |   116.02 ns |  0.260 ns |  0.243 ns |  1.30 |    0.00 | 0.0067 |     - |     - |      56 B |
|       ProtobufNet |   348.45 ns |  2.508 ns |  2.223 ns |  3.92 |    0.02 | 0.0067 |     - |     - |      56 B |
|          Hyperion |   141.01 ns |  0.723 ns |  0.677 ns |  1.59 |    0.01 | 0.0067 |     - |     - |      56 B |
|    NewtonsoftJson | 3,546.77 ns | 40.219 ns | 37.621 ns | 39.84 |    0.49 | 0.3395 |     - |     - |    2856 B |
|          SpanJson |   236.66 ns |  0.876 ns |  0.731 ns |  2.66 |    0.01 | 0.0067 |     - |     - |      56 B |
```  

StructSerializeBenchmark:
```
|            Method |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated | Payload |
|------------------ |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|--------:|
|             Hagar |    62.40 ns |  0.349 ns |  0.309 ns |  1.00 |    0.00 |      - |     - |     - |         - |    20 B |
|         Hagar Old |    73.98 ns |  1.518 ns |  3.426 ns |  1.19 |       - |      - |     - |     - |         - |    20 B |
|          Utf8Json |   154.15 ns |  3.014 ns |  4.023 ns |  2.47 |    0.08 |      - |     - |     - |         - |   154 B |
|    SystemTextJson |   509.64 ns |  2.050 ns |  1.817 ns |  8.17 |    0.05 | 0.0067 |     - |     - |      56 B |   154 B |
| MessagePackCSharp |   161.70 ns |  0.377 ns |  0.352 ns |  2.59 |    0.02 | 0.0048 |     - |     - |      40 B |    10 B |
|       ProtobufNet |   252.80 ns |  1.659 ns |  1.552 ns |  4.05 |    0.03 |      - |     - |     - |         - |    18 B |
|          Hyperion |   113.88 ns |  0.424 ns |  0.375 ns |  1.83 |    0.01 | 0.0067 |     - |     - |      56 B |    39 B |
|    NewtonsoftJson | 1,758.61 ns | 25.997 ns | 24.318 ns | 28.16 |    0.37 | 0.2480 |     - |     - |    2080 B |   154 B |
|          SpanJson |   120.34 ns |  0.456 ns |  0.381 ns |  1.93 |    0.01 | 0.0219 |     - |     - |     184 B |   154 B |
```

StructDeserializeBenchmark:
```
|            Method |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|             Hagar |    73.28 ns |  0.361 ns |  0.320 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         Hagar Old |    76.66 ns |  1.391 ns |  1.429 ns |  1.05 |         |      - |     - |     - |         - |
|          Utf8Json |   458.93 ns |  2.600 ns |  2.432 ns |  6.26 |    0.05 |      - |     - |     - |         - |
|    SystemTextJson | 1,143.01 ns | 14.180 ns | 13.264 ns | 15.57 |    0.16 | 0.0057 |     - |     - |      56 B |
| MessagePackCSharp |   116.73 ns |  0.193 ns |  0.171 ns |  1.59 |    0.01 |      - |     - |     - |         - |
|       ProtobufNet |   324.41 ns |  3.601 ns |  3.368 ns |  4.43 |    0.05 |      - |     - |     - |         - |
|          Hyperion |   109.90 ns |  0.432 ns |  0.405 ns |  1.50 |    0.01 | 0.0067 |     - |     - |      56 B |
|    NewtonsoftJson | 5,595.86 ns | 35.413 ns | 33.125 ns | 76.33 |    0.49 | 0.4044 |     - |     - |    3432 B |
|          SpanJson |   230.10 ns |  1.042 ns |  0.924 ns |  3.14 |    0.02 |      - |     - |     - |         - |
```