### PR TITLE
Remove WireType.Fixed128

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ public enum WireType : byte
     LengthPrefixed = 0b010 << 5, // Followed by VarInt length representing the number of bytes which follow.
     Fixed32 = 0b011 << 5, // Followed by 4 bytes
     Fixed64 = 0b100 << 5, // Followed by 8 bytes
-    Fixed128 = 0b101 << 5, // Followed by 16 bytes
     Reference = 0b110 << 5, // Followed by a VarInt reference to a previously defined object. Note that the SchemaType and type specification must still be included.
     Extended = 0b111 << 5, // This is a control tag. The schema type and embedded field id are invalid. The remaining 5 bits are used for control information.
 }

--- a/src/Hagar/Codecs/ConsumeFieldExtension.cs
+++ b/src/Hagar/Codecs/ConsumeFieldExtension.cs
@@ -39,9 +39,9 @@ namespace Hagar.Codecs
                 case WireType.Fixed64:
                     reader.Skip(8);
                     break;
-                case WireType.Fixed128:
-                    reader.Skip(16);
-                    break;
+                //case WireType.Fixed128:
+                //    reader.Skip(16);
+                //    break;
                 case WireType.Extended:
                     SkipFieldExtension.ThrowUnexpectedExtendedWireType(field);
                     break;

--- a/src/Hagar/Codecs/ConsumeFieldExtension.cs
+++ b/src/Hagar/Codecs/ConsumeFieldExtension.cs
@@ -39,9 +39,6 @@ namespace Hagar.Codecs
                 case WireType.Fixed64:
                     reader.Skip(8);
                     break;
-                //case WireType.Fixed128:
-                //    reader.Skip(16);
-                //    break;
                 case WireType.Extended:
                     SkipFieldExtension.ThrowUnexpectedExtendedWireType(field);
                     break;

--- a/src/Hagar/Codecs/FloatCodec.cs
+++ b/src/Hagar/Codecs/FloatCodec.cs
@@ -8,6 +8,8 @@ namespace Hagar.Codecs
     [RegisterSerializer]
     public sealed class FloatCodec : TypedCodecBase<float, FloatCodec>, IFieldCodec<float>
     {
+        private const int DecimalWidth = 16;
+
         void IFieldCodec<float>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
             uint fieldIdDelta,
             Type expectedType,
@@ -42,8 +44,13 @@ namespace Hagar.Codecs
                         return (float)value;
                     }
 
-                case WireType.Fixed128:
+                case WireType.LengthPrefixed:
                     // Decimal has a smaller range, but higher precision than float.
+                    var length = reader.ReadVarUInt32();
+                    if (length != DecimalWidth)
+                    {
+                        throw new UnexpectedLengthPrefixValueException("float", DecimalWidth, length, field.ToString());
+                    }
                     return (float)reader.ReadDecimal();
 
                 default:
@@ -62,6 +69,8 @@ namespace Hagar.Codecs
     [RegisterSerializer]
     public sealed class DoubleCodec : TypedCodecBase<double, DoubleCodec>, IFieldCodec<double>
     {
+        private const int DecimalWidth = 16;
+
         void IFieldCodec<double>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer,
             uint fieldIdDelta,
             Type expectedType,
@@ -87,7 +96,12 @@ namespace Hagar.Codecs
                     return reader.ReadFloat();
                 case WireType.Fixed64:
                     return reader.ReadDouble();
-                case WireType.Fixed128:
+                case WireType.LengthPrefixed:
+                    var length = reader.ReadVarUInt32();
+                    if (length != DecimalWidth)
+                    {
+                        throw new UnexpectedLengthPrefixValueException("double", DecimalWidth, length, field.ToString());
+                    }
                     return (double)reader.ReadDecimal();
                 default:
                     ThrowWireTypeOutOfRange(field.WireType);
@@ -102,12 +116,15 @@ namespace Hagar.Codecs
     [RegisterSerializer]
     public sealed class DecimalCodec : TypedCodecBase<decimal, DecimalCodec>, IFieldCodec<decimal>
     {
+        private const int Width = 16;
+
         void IFieldCodec<decimal>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, decimal value) => WriteField(ref writer, fieldIdDelta, expectedType, value);
 
         public static void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, decimal value) where TBufferWriter : IBufferWriter<byte>
         {
             ReferenceCodec.MarkValueField(writer.Session);
-            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(decimal), WireType.Fixed128);
+            writer.WriteFieldHeader(fieldIdDelta, expectedType, typeof(decimal), WireType.LengthPrefixed);
+            writer.WriteVarInt(Width);
             var ints = decimal.GetBits(value);
             foreach (var part in ints)
             {
@@ -142,7 +159,12 @@ namespace Hagar.Codecs
 
                         return (decimal)value;
                     }
-                case WireType.Fixed128:
+                case WireType.LengthPrefixed:
+                    var length = reader.ReadVarUInt32();
+                    if (length != Width)
+                    {
+                        throw new UnexpectedLengthPrefixValueException("decimal", Width, length, field.ToString());
+                    }
                     return reader.ReadDecimal();
                 default:
                     ThrowWireTypeOutOfRange(field.WireType);

--- a/src/Hagar/Codecs/SkipFieldExtension.cs
+++ b/src/Hagar/Codecs/SkipFieldExtension.cs
@@ -46,10 +46,10 @@ namespace Hagar.Codecs
                     reader.Session.ReferencedObjects.MarkValueField();
                     reader.Skip(8);
                     break;
-                case WireType.Fixed128:
-                    reader.Session.ReferencedObjects.MarkValueField();
-                    reader.Skip(16);
-                    break;
+                //case WireType.Fixed128:
+                //    reader.Session.ReferencedObjects.MarkValueField();
+                //    reader.Skip(16);
+                //    break;
                 case WireType.Extended:
                     if (!field.IsEndBaseOrEndObject)
                     {

--- a/src/Hagar/Codecs/SkipFieldExtension.cs
+++ b/src/Hagar/Codecs/SkipFieldExtension.cs
@@ -46,10 +46,6 @@ namespace Hagar.Codecs
                     reader.Session.ReferencedObjects.MarkValueField();
                     reader.Skip(8);
                     break;
-                //case WireType.Fixed128:
-                //    reader.Session.ReferencedObjects.MarkValueField();
-                //    reader.Skip(16);
-                //    break;
                 case WireType.Extended:
                     if (!field.IsEndBaseOrEndObject)
                     {

--- a/src/Hagar/Exceptions.cs
+++ b/src/Hagar/Exceptions.cs
@@ -221,6 +221,7 @@ namespace Hagar
         {
         }
     }
+
     [Serializable]
     public class CodecNotFoundException : HagarException
     {
@@ -232,4 +233,22 @@ namespace Hagar
         {
         }
     }
+
+    [Serializable]
+    public class UnexpectedLengthPrefixValueException : HagarException
+    {
+        public UnexpectedLengthPrefixValueException(string message) : base(message)
+        {
+        }
+
+        public UnexpectedLengthPrefixValueException(string typeName, uint expectedLength, uint actualLength, string additionaInfo)
+            : base($"VarInt length specified in header for {typeName} should be {expectedLength} but is instead {actualLength}. {additionaInfo}")
+        {
+        }
+
+        protected UnexpectedLengthPrefixValueException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
 }

--- a/src/Hagar/Utilities/BitStreamFormatter.cs
+++ b/src/Hagar/Utilities/BitStreamFormatter.cs
@@ -139,13 +139,13 @@ namespace Hagar.Utilities
                         }
                     }
                     break;
-                case WireType.Fixed128:
-                    {
-                        var a = reader.ReadUInt64();
-                        var b = reader.ReadUInt64();
-                        res.Append($"{a:X16}{b:X16}");
-                    }
-                    break;
+                //case WireType.Fixed128:
+                //    {
+                //        var a = reader.ReadUInt64();
+                //        var b = reader.ReadUInt64();
+                //        res.Append($"{a:X16}{b:X16}");
+                //    }
+                //    break;
                 case WireType.Extended:
                     SkipFieldExtension.ThrowUnexpectedExtendedWireType(field);
                     break;

--- a/src/Hagar/Utilities/BitStreamFormatter.cs
+++ b/src/Hagar/Utilities/BitStreamFormatter.cs
@@ -139,13 +139,6 @@ namespace Hagar.Utilities
                         }
                     }
                     break;
-                //case WireType.Fixed128:
-                //    {
-                //        var a = reader.ReadUInt64();
-                //        var b = reader.ReadUInt64();
-                //        res.Append($"{a:X16}{b:X16}");
-                //    }
-                //    break;
                 case WireType.Extended:
                     SkipFieldExtension.ThrowUnexpectedExtendedWireType(field);
                     break;

--- a/src/Hagar/WireProtocol/WireType.cs
+++ b/src/Hagar/WireProtocol/WireType.cs
@@ -10,7 +10,6 @@ namespace Hagar.WireProtocol
         LengthPrefixed = 0b010 << 5, // Followed by VarInt length representing the number of bytes which follow.
         Fixed32 = 0b011 << 5, // Followed by 4 bytes
         Fixed64 = 0b100 << 5, // Followed by 8 bytes
-        // Fixed128 = 0b101 << 5, // Followed by 16 bytes
         Reference = 0b110 << 5, // Followed by a VarInt reference to a previously defined object. Note that the SchemaType and type specification must still be included.
         Extended = 0b111 << 5, // This is a control tag. The schema type and embedded field id are invalid. The remaining 5 bits are used for control information.
     }

--- a/src/Hagar/WireProtocol/WireType.cs
+++ b/src/Hagar/WireProtocol/WireType.cs
@@ -10,7 +10,7 @@ namespace Hagar.WireProtocol
         LengthPrefixed = 0b010 << 5, // Followed by VarInt length representing the number of bytes which follow.
         Fixed32 = 0b011 << 5, // Followed by 4 bytes
         Fixed64 = 0b100 << 5, // Followed by 8 bytes
-        Fixed128 = 0b101 << 5, // Followed by 16 bytes
+        // Fixed128 = 0b101 << 5, // Followed by 16 bytes
         Reference = 0b110 << 5, // Followed by a VarInt reference to a previously defined object. Note that the SchemaType and type specification must still be included.
         Extended = 0b111 << 5, // This is a control tag. The schema type and embedded field id are invalid. The remaining 5 bits are used for control information.
     }


### PR DESCRIPTION
For Issue #105.

Rewrote Guid, Float, Double, and Decimal codecs to use WireType.LengthPrefixed instead