### PR TITLE
Prevent Source Generator from running during editing

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,5 +4,11 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(HagarBuildTimeCodeGen)' == 'true' ">
+    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+  </ItemGroup>
+ 
+  <Import Condition=" '$(HagarBuildTimeCodeGen)' == 'true' " Project="$(MSBuildThisFileDirectory)src/Hagar.CodeGenerator/build/Hagar.CodeGenerator.props" />
+
 </Project>
 

--- a/TestRpc/TestRpc.csproj
+++ b/TestRpc/TestRpc.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
-    <!--<HagarCodeGenWaitForDebugger>true</HagarCodeGenWaitForDebugger>-->
+    <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\src\Hagar.ISerializable\Hagar.ISerializable.csproj" />
     <ProjectReference Include="..\src\Hagar\Hagar.csproj" />
-    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>

--- a/src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj
+++ b/src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj
@@ -3,7 +3,28 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageDescription>Code generation library for Hagar</PackageDescription>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
+
+	<ItemGroup> 
+		<None Remove="buildMultiTargeting\Hagar.CodeGenerator.props" />
+		<None Remove="build\Hagar.CodeGenerator.props" />
+		<Content Include="buildMultiTargeting\Hagar.CodeGenerator.props">
+		  <PackagePath>%(Identity)</PackagePath>
+		  <Visible>true</Visible>
+		  <Pack>true</Pack>
+		</Content>
+		<Content Include="build\Hagar.CodeGenerator.props">
+		  <PackagePath>%(Identity)</PackagePath>
+		  <Visible>true</Visible>
+		  <Pack>true</Pack>
+		</Content>
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<None Include="$(OutputPath)\$(AssemblyName).xml" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />

--- a/src/Hagar.CodeGenerator/HagarSourceGenerator.cs
+++ b/src/Hagar.CodeGenerator/HagarSourceGenerator.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using System;
 using System.Text;
 
 namespace Hagar.CodeGenerator
@@ -9,6 +10,18 @@ namespace Hagar.CodeGenerator
     {
         public void Execute(GeneratorExecutionContext context)
         {
+            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.hagar_attachdebugger", out var attachDebuggerOption)
+                && string.Equals("true", attachDebuggerOption, StringComparison.OrdinalIgnoreCase))
+            {
+                System.Diagnostics.Debugger.Launch();
+            }
+
+            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.hagar_designtimebuild", out var isDesignTimeBuild)
+                && string.Equals("true", isDesignTimeBuild, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
             var codeGenerator = new CodeGenerator(context.Compilation, new CodeGeneratorOptions());
             var syntax = codeGenerator.GenerateCode(context.CancellationToken);
             var sourceString = syntax.NormalizeWhitespace().ToFullString();
@@ -18,12 +31,6 @@ namespace Hagar.CodeGenerator
 
         public void Initialize(GeneratorInitializationContext context)
         {
-#if false
-            if (!System.Diagnostics.Debugger.IsAttached)
-            {
-                System.Diagnostics.Debugger.Launch();
-            }
-#endif 
         }
     }
 }

--- a/src/Hagar.CodeGenerator/build/Hagar.CodeGenerator.props
+++ b/src/Hagar.CodeGenerator/build/Hagar.CodeGenerator.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="Hagar_DesignTimeBuild" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="Hagar_AttachDebugger" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <Hagar_DesignTimeBuild>$(DesignTimeBuild)</Hagar_DesignTimeBuild>
+  </PropertyGroup>
+
+</Project>

--- a/src/Hagar.CodeGenerator/buildMultiTargeting/Hagar.CodeGenerator.props
+++ b/src/Hagar.CodeGenerator/buildMultiTargeting/Hagar.CodeGenerator.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Hagar.CodeGenerator.props" />
+</Project>

--- a/src/Hagar/Hagar.csproj
+++ b/src/Hagar/Hagar.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net48;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageDescription>Fast, flexible, and version-tolerant serializer for .NET</PackageDescription>
+    <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,7 +26,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Hagar.Abstractions\Hagar.Abstractions.csproj" />
-    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(SourceRoot)src/Hagar.Analyzers/Hagar.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -10,6 +10,7 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>9.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>
@@ -49,7 +50,6 @@
     <ProjectReference Include="..\..\src\Hagar.ISerializable\Hagar.ISerializable.csproj" />
     <ProjectReference Include="..\..\src\Hagar.NewtonsoftJson\Hagar.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\..\src\Hagar\Hagar.csproj" />
-    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>

--- a/test/CallLog/CallLog.csproj
+++ b/test/CallLog/CallLog.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hagar.ISerializable\Hagar.ISerializable.csproj" />
     <ProjectReference Include="..\..\src\Hagar\Hagar.csproj" />
-    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(SourceRoot)src/Hagar.Analyzers/Hagar.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/test/Hagar.UnitTests/BuiltInCodecTests.cs
+++ b/test/Hagar.UnitTests/BuiltInCodecTests.cs
@@ -13,7 +13,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Hagar.UnitTests

--- a/test/Hagar.UnitTests/Hagar.UnitTests.csproj
+++ b/test/Hagar.UnitTests/Hagar.UnitTests.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net5.0;net48</TargetFrameworks>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,7 +43,6 @@
     <ProjectReference Include="..\..\src\Hagar.ISerializable\Hagar.ISerializable.csproj" />
     <ProjectReference Include="..\..\src\Hagar.TestKit\Hagar.TestKit.csproj" />
     <ProjectReference Include="..\..\src\Hagar\Hagar.csproj" />
-    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(SourceRoot)src/Hagar.Analyzers/Hagar.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>9</LangVersion>
+    <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +19,6 @@
     <ProjectReference Include="..\..\src\Hagar.ISerializable\Hagar.ISerializable.csproj" />
     <ProjectReference Include="..\..\src\Hagar.NewtonsoftJson\Hagar.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\..\src\Hagar\Hagar.csproj" />
-    <ProjectReference Include="$(SourceRoot)src/Hagar.CodeGenerator/Hagar.CodeGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This improves the editing performance. There is no need to run code generation during the editing experience for this Source Generator