### PR TITLE
Explicitly version type encoding

### DIFF
--- a/src/Hagar/Serializers/CodecProvider.cs
+++ b/src/Hagar/Serializers/CodecProvider.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/Hagar/Serializers/IValueSerializer.cs
+++ b/src/Hagar/Serializers/IValueSerializer.cs
@@ -1,6 +1,5 @@
 using Hagar.Buffers;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Hagar.Serializers
 {

--- a/src/Hagar/Session/ReferencedObjectCollection.cs
+++ b/src/Hagar/Session/ReferencedObjectCollection.cs
@@ -37,7 +37,6 @@ namespace Hagar.Session
                 return true;
             }
 
-            // TODO: Binary search
             for (int i = 0; i < ReferenceToObjectCount; ++i)
             {
                 if (_referenceToObject[i].Id == reference)
@@ -67,7 +66,6 @@ namespace Hagar.Session
                 return true;
             }
 
-            // TODO: Binary search
             for (int i = 0; i < _objectToReferenceCount; ++i)
             {
                 if (ReferenceEquals(_objectToReference[i].Object, value))
@@ -91,7 +89,6 @@ namespace Hagar.Session
                 return -1;
             }
 
-            // TODO: Binary search
             for (var i = 0; i < ReferenceToObjectCount; ++i)
             {
                 if (ReferenceEquals(_referenceToObject[i].Object, value))


### PR DESCRIPTION
In order to facilitate versioning the type encoding scheme, use a byte to indicate a version number