### PR TITLE
Add DeepCopier types

### DIFF
--- a/src/Hagar.TestKit/CopierTester.cs
+++ b/src/Hagar.TestKit/CopierTester.cs
@@ -31,6 +31,8 @@ namespace Hagar.TestKit
 
         protected IServiceProvider ServiceProvider => _serviceProvider;
 
+        protected virtual bool IsImmutable => false;
+
         protected virtual void Configure(IHagarBuilder builder)
         {
         }
@@ -60,6 +62,26 @@ namespace Hagar.TestKit
             {
                 var output = copier.DeepCopy(original, new CopyContext());
                 Assert.True(Equals(original, output), $"Copy value \"{output}\" must equal original value \"{original}\"");
+            }
+        }
+
+        [Fact]
+        public void ReferencesAreAddedToCopyContext()
+        {
+            if (typeof(TValue).IsValueType)
+            {
+                return;
+            }
+
+            var value = CreateValue();
+            var array = new TValue[] { value, value };
+            var arrayCopier = _serviceProvider.GetRequiredService<DeepCopier<TValue[]>>();
+            var arrayCopy = arrayCopier.Copy(array);
+            Assert.Same(arrayCopy[0], arrayCopy[1]);
+
+            if (!IsImmutable)
+            {
+                Assert.NotSame(value, arrayCopy[0]);
             }
         }
     }

--- a/src/Hagar/Cloning/IDeepCopier.cs
+++ b/src/Hagar/Cloning/IDeepCopier.cs
@@ -80,6 +80,8 @@ namespace Hagar.Cloning
             public override bool Equals(object x, object y) => ReferenceEquals(x, y);
             public override int GetHashCode(object obj) => obj is null ? 0 : RuntimeHelpers.GetHashCode(obj);
         }
+
+        public void Reset() => _copies.Clear();
     }
 
     internal static class ShallowCopyableTypes

--- a/src/Hagar/Hosting/ServiceProviderExtensions.cs
+++ b/src/Hagar/Hosting/ServiceProviderExtensions.cs
@@ -52,9 +52,11 @@ namespace Hagar
                 services.TryAddSingleton<SerializerSessionPool>();
 
                 // Serializer
-                services.TryAddSingleton(typeof(Serializer));
+                services.TryAddSingleton<Serializer>();
                 services.TryAddSingleton(typeof(Serializer<>));
                 services.TryAddSingleton(typeof(ValueSerializer<>));
+                services.TryAddSingleton<DeepCopier>();
+                services.TryAddSingleton(typeof(DeepCopier<>));
             }
 
             configure?.Invoke(context.Builder);

--- a/src/Hagar/Serializers/CodecProvider.cs
+++ b/src/Hagar/Serializers/CodecProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -93,10 +94,7 @@ namespace Hagar.Serializers
 
             static void AddFromMetadata(IDictionary<Type, Type> resultCollection, IEnumerable<Type> metadataCollection, Type genericType)
             {
-                if (genericType.GetGenericArguments().Length != 1)
-                {
-                    throw new ArgumentException($"Type {genericType} must have an arity of 1.");
-                }
+                Debug.Assert(genericType.GetGenericArguments().Length == 1);
 
                 foreach (var type in metadataCollection)
                 {

--- a/src/Hagar/Serializers/ConcreteTypeSerializer.cs
+++ b/src/Hagar/Serializers/ConcreteTypeSerializer.cs
@@ -77,46 +77,4 @@ namespace Hagar.Serializers
             return result;
         }
     }
-
-    /// <summary>
-    /// Serializer for reference types which can be instantiated.
-    /// </summary>
-    /// <typeparam name="TField">The field type.</typeparam>
-    /// <typeparam name="TPartialSerializer">The partial serializer implementation type.</typeparam>
-    public sealed class SealedTypeSerializer<TField, TPartialSerializer> : IFieldCodec<TField> where TField : class where TPartialSerializer : IPartialSerializer<TField>
-    {
-        private readonly IActivator<TField> _activator;
-        private readonly TPartialSerializer _serializer;
-
-        public SealedTypeSerializer(IActivator<TField> activator, TPartialSerializer serializer)
-        {
-            _activator = activator;
-            _serializer = serializer;
-        }
-
-        public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TField value) where TBufferWriter : IBufferWriter<byte>
-        {
-            if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, value))
-            {
-                return;
-            }
-
-            writer.WriteStartObject(fieldIdDelta, expectedType, expectedType); 
-            _serializer.Serialize(ref writer, value);
-            writer.WriteEndObject();
-        }
-
-        public TField ReadValue<TInput>(ref Reader<TInput> reader, Field field)
-        {
-            if (field.WireType == WireType.Reference)
-            {
-                return ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
-            }
-
-            var result = _activator.Create();
-            ReferenceCodec.RecordObject(reader.Session, result);
-            _serializer.Deserialize(ref reader, result);
-            return result;
-        }
-    }
 }

--- a/test/Hagar.UnitTests/BuiltInCodecTests.cs
+++ b/test/Hagar.UnitTests/BuiltInCodecTests.cs
@@ -179,6 +179,8 @@ namespace Hagar.UnitTests
         };
 
         protected override bool Equals(Version left, Version right) => left == right && (left is null || left.GetHashCode() == right.GetHashCode());
+
+        protected override bool IsImmutable => true;
     }
 
     public class BitVector32Tests: FieldCodecTester<BitVector32, BitVector32Codec>
@@ -817,6 +819,8 @@ namespace Hagar.UnitTests
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
         protected override string[] TestValues => new[] { null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!" };
+
+        protected override bool IsImmutable => true;
     }
 
     public class ObjectCodecTests : FieldCodecTester<object, ObjectCodec>
@@ -1337,6 +1341,8 @@ namespace Hagar.UnitTests
 
         protected override Type CreateValue() => _values[_valueIndex++ % _values.Length];
         protected override Type[] TestValues => _values;
+
+        protected override bool IsImmutable => true;
     }
 
     public class FloatCodecTests : FieldCodecTester<float, FloatCodec>
@@ -1800,7 +1806,9 @@ namespace Hagar.UnitTests
 
             rand.NextBytes(bytes);
             return new IPAddress(bytes);
-        } 
+        }
+
+        protected override bool IsImmutable => true;
     }
 
     public class HashSetTests : FieldCodecTester<HashSet<string>, HashSetCodec<string>>
@@ -1877,5 +1885,7 @@ namespace Hagar.UnitTests
         protected override ImmutableHashSet<string>[] TestValues => new[] { null, ImmutableHashSet.Create<string>(), CreateValue(), CreateValue(), CreateValue() };
 
         protected override bool Equals(ImmutableHashSet<string> left, ImmutableHashSet<string> right) => object.ReferenceEquals(left, right) || left.SetEquals(right);
+
+        protected override bool IsImmutable => true;
     }
 }

--- a/test/Hagar.UnitTests/Hagar.UnitTests.csproj
+++ b/test/Hagar.UnitTests/Hagar.UnitTests.csproj
@@ -26,9 +26,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.8.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.9.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.9.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
This PR adds helper `DeepCopier` & `DeepCopier<T>` types with `Copy<T>(T value)` & `Copy(T value)` methods, respectively.

Follow-on to #132
Related to #48 