### PR TITLE
Improve performance for large serialization graphs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Reuben Bond</Authors>
     <Product>Hagar</Product>
-    <VersionPrefix>0.5.4</VersionPrefix>
+    <VersionPrefix>0.5.5</VersionPrefix>
     <Copyright>Copyright © Reuben Bond 2020</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ReubenBond/Hagar</PackageProjectUrl>

--- a/src/Hagar/Cloning/IDeepCopier.cs
+++ b/src/Hagar/Cloning/IDeepCopier.cs
@@ -1,4 +1,5 @@
 ﻿using Hagar.Serializers;
+using Hagar.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -48,9 +49,7 @@ namespace Hagar.Cloning
 
     public sealed class CopyContext
     {
-        private static ReferenceEqualsComparer Comparer { get; } = new ReferenceEqualsComparer();
-
-        private readonly Dictionary<object, object> _copies = new(Comparer);
+        private readonly Dictionary<object, object> _copies = new(ReferenceEqualsComparer.Default);
 
         public bool TryGetCopy<T>(object original, out T result) where T : class
         {
@@ -73,12 +72,6 @@ namespace Hagar.Cloning
         public void RecordCopy(object original, object copy)
         {
             _copies[original] = copy;
-        }
-
-        private class ReferenceEqualsComparer : EqualityComparer<object>
-        {
-            public override bool Equals(object x, object y) => ReferenceEquals(x, y);
-            public override int GetHashCode(object obj) => obj is null ? 0 : RuntimeHelpers.GetHashCode(obj);
         }
 
         public void Reset() => _copies.Clear();

--- a/src/Hagar/Utilities/ReferenceEqualsComparer.cs
+++ b/src/Hagar/Utilities/ReferenceEqualsComparer.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Hagar.Utilities
+{
+    internal sealed class ReferenceEqualsComparer : EqualityComparer<object>
+    {
+        public override bool Equals(object x, object y) => ReferenceEquals(x, y);
+        public override int GetHashCode(object obj) => obj is null ? 0 : RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -11,6 +11,7 @@
     <LangVersion>9.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
+    <ServerGC>true</ServerGC>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Benchmarks/MegaGraphBenchmark.cs
+++ b/test/Benchmarks/MegaGraphBenchmark.cs
@@ -1,0 +1,145 @@
+using BenchmarkDotNet.Attributes;
+using Benchmarks.Utilities;
+using Hagar;
+using Hagar.Buffers;
+using Hagar.Session;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO.Pipelines;
+using System.Linq;
+using Xunit;
+using SerializerSession = Hagar.Session.SerializerSession;
+
+namespace Benchmarks
+{
+    [Trait("Category", "Benchmark")]
+    [Config(typeof(BenchmarkConfig))]
+    public class MegaGraphBenchmark
+    {
+        private static readonly Serializer<Dictionary<string, int>> HagarSerializer;
+        private static readonly byte[] HagarInput;
+        private static readonly SerializerSession Session;
+        private static readonly Dictionary<string, int> Value;
+
+        static MegaGraphBenchmark()
+        {
+            const int Size = 250_000;
+            Value = new Dictionary<string, int>(Size);
+            for (var i = 0; i < Size; i++)
+            {
+                Value[i.ToString(CultureInfo.InvariantCulture)] = i;
+            }
+            
+            var services = new ServiceCollection()
+                .AddHagar(hagar => hagar.AddAssembly(typeof(Program).Assembly))
+                .BuildServiceProvider();
+            HagarSerializer = services.GetRequiredService<Serializer<Dictionary<string, int>>>();
+            Session = services.GetRequiredService<SerializerSessionPool>().GetSession();
+            var pipe = new Pipe(new PipeOptions(readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline));
+            var writer = pipe.Writer.CreateWriter(Session);
+            HagarSerializer.Serialize(Value, ref writer);
+            pipe.Writer.FlushAsync();
+            pipe.Reader.TryRead(out var result);
+            HagarInput = result.Buffer.ToArray();
+        }
+
+        [Fact]
+        [Benchmark]
+        public object Deserialize()
+        {
+            Session.FullReset();
+            var instance = HagarSerializer.Deserialize(HagarInput, Session);
+            return instance;
+        }
+
+        [Fact]
+        [Benchmark]
+        public int Serialize()
+        {
+            Session.FullReset();
+            using (var buffer = new FakePooledBufferWriter(4096))
+            {
+                var writer = buffer.CreateWriter(Session);
+                HagarSerializer.Serialize(Value, ref writer);
+                return writer.Position;
+            }
+        }
+
+        public class FakePooledBufferWriter : IBufferWriter<byte>, IDisposable
+        {
+            private readonly List<(byte[], int)> _committed = new();
+            private readonly int _maxAllocationSize;
+            private byte[] _current = Array.Empty<byte>();
+
+            public FakePooledBufferWriter(int maxAllocationSize)
+            {
+                _maxAllocationSize = maxAllocationSize;
+            }
+
+            public void Advance(int bytes)
+            {
+                if (bytes == 0)
+                {
+                    return;
+                }
+
+                _committed.Add((_current, bytes));
+                _current = Array.Empty<byte>();
+            }
+
+            public void Dispose()
+            {
+                foreach (var (array, _) in _committed)
+                {
+                    if (array.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    ArrayPool<byte>.Shared.Return(array);
+                }
+
+                _committed.Clear();
+            }
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                if (sizeHint == 0)
+                {
+                    sizeHint = _current.Length + 1;
+                }
+
+                if (sizeHint < _current.Length)
+                {
+                    throw new InvalidOperationException("Attempted to allocate a new buffer when the existing buffer has sufficient free space.");
+                }
+
+                var newBuffer = ArrayPool<byte>.Shared.Rent(Math.Min(sizeHint, _maxAllocationSize));
+                _current.CopyTo(newBuffer.AsSpan());
+                _current = newBuffer;
+                return _current;
+            }
+
+            public Span<byte> GetSpan(int sizeHint)
+            {
+                if (sizeHint == 0)
+                {
+                    sizeHint = _current.Length + 1;
+                }
+
+                if (sizeHint < _current.Length)
+                {
+                    throw new InvalidOperationException("Attempted to allocate a new buffer when the existing buffer has sufficient free space.");
+                }
+
+                var newBuffer = ArrayPool<byte>.Shared.Rent(Math.Min(sizeHint, _maxAllocationSize));
+                _current.CopyTo(newBuffer.AsSpan());
+                _current = newBuffer;
+                return _current;
+            }
+        }
+    }
+}

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -69,7 +69,8 @@ namespace Benchmarks
                 typeof(StructDeserializeBenchmark),
                 typeof(ComplexTypeBenchmarks),
                 typeof(FieldHeaderBenchmarks),
-                typeof(MessageBenchmark)
+                typeof(MessageBenchmark),
+                typeof(MegaGraphBenchmark)
             });
 
             _ = switcher.Run(args);


### PR DESCRIPTION
When serializing very large object graphs, the current implementation of `ReferencedObjectCollection` can degrade substantially. This PR introduces a speedup of up to 400x in those cases by using a hybrid data structure in `ReferencedObjectCollection`