### PR TITLE
More small fixes

### DIFF
--- a/src/Hagar.CodeGenerator/Model/MetadataModel.cs
+++ b/src/Hagar.CodeGenerator/Model/MetadataModel.cs
@@ -5,15 +5,11 @@ namespace Hagar.CodeGenerator
 {
     internal class MetadataModel
     {
-        public List<ISerializableTypeDescription> SerializableTypes { get; } =
-            new(1024);
-
-        public List<IInvokableInterfaceDescription> InvokableInterfaces { get; } =
-            new(1024);
+        public List<ISerializableTypeDescription> SerializableTypes { get; } = new(1024);
+        public List<IInvokableInterfaceDescription> InvokableInterfaces { get; } = new(1024);
         public Dictionary<MethodDescription, IGeneratedInvokerDescription> GeneratedInvokables { get; } = new();
         public List<IGeneratedProxyDescription> GeneratedProxies { get; } = new(1024);
-        public List<ISerializableTypeDescription> ActivatableTypes { get; } =
-            new(1024);
+        public List<ISerializableTypeDescription> ActivatableTypes { get; } = new(1024);
         public List<INamedTypeSymbol> DetectedSerializers { get; } = new();
         public List<INamedTypeSymbol> DetectedActivators { get; } = new();
         public List<INamedTypeSymbol> DetectedCopiers { get; } = new();

--- a/src/Hagar/Codecs/UnknownFieldMarker.cs
+++ b/src/Hagar/Codecs/UnknownFieldMarker.cs
@@ -24,6 +24,7 @@ namespace Hagar.Codecs
         public Field Field { get; }
 
         /// <inheritdoc />
-        public override string ToString() => $"{nameof(Position)}: {Position}, {nameof(Field)}: {Field}";
+        public override string ToString() => $"{nameof(Position)}: 0x{Position:X}, {nameof(Field)}: {Field}";
+
     }
 }

--- a/src/Hagar/Session/ReferencedObjectCollection.cs
+++ b/src/Hagar/Session/ReferencedObjectCollection.cs
@@ -182,7 +182,7 @@ namespace Hagar.Session
             void CreateReferenceToObjectOverflow()
             {
                 var result = new Dictionary<uint, object>();
-                for (var i = 0; i < ReferenceToObjectCount - 1; i++)
+                for (var i = 0; i < ReferenceToObjectCount; i++)
                 {
                     var record = _referenceToObject[i];
                     result[record.Id] = record.Object;


### PR DESCRIPTION
This fixes an off-by-one error in the ReferencedObjectCollection when spilling over from an array into a dictionary.
This also adds more allowed types from code generation