### PR TITLE
Register UriCopier as a copier

### DIFF
--- a/src/Hagar/Codecs/UriCodec.cs
+++ b/src/Hagar/Codecs/UriCodec.cs
@@ -37,7 +37,7 @@ namespace Hagar.Codecs
         public string Value { get; set; }
     }
 
-    [RegisterSerializer]
+    [RegisterCopier]
     public sealed class UriCopier : IDeepCopier<Uri>, IGeneralizedCopier
     {
         public Uri DeepCopy(Uri input, CopyContext context) => input;

--- a/test/Hagar.UnitTests/BuiltInCodecTests.cs
+++ b/test/Hagar.UnitTests/BuiltInCodecTests.cs
@@ -1905,4 +1905,25 @@ namespace Hagar.UnitTests
 
         protected override bool IsImmutable => true;
     }
+
+    public class UriTests : FieldCodecTester<Uri, UriCodec>
+    {
+        protected override int[] MaxSegmentSizes => new[] { 128 };
+        protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
+
+        protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+
+        protected override bool Equals(Uri left, Uri right) => object.ReferenceEquals(left, right) || left == right;
+    }
+
+    public class UriCopierTests : CopierTester<Uri, UriCopier>
+    {
+        protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
+
+        protected override Uri[] TestValues => new[] { null, CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+
+        protected override bool Equals(Uri left, Uri right) => object.ReferenceEquals(left, right) || left == right;
+
+        protected override bool IsImmutable => true;
+    }
 }


### PR DESCRIPTION
Currently getting the following error when performing DeepCopy() on a type with a System.Uri field:
`Hagar.CodecNotFoundException: Could not find a copier for type System.Uri.`
