### PR TITLE
Fix incremental builds

### DIFF
--- a/src/Hagar.CodeGenerator.MSBuild/build/Hagar.CodeGenerator.MSBuild.targets
+++ b/src/Hagar.CodeGenerator.MSBuild/build/Hagar.CodeGenerator.MSBuild.targets
@@ -61,7 +61,7 @@
     Name="HagarGenerateInputCache"
     DependsOnTargets="ResolveAssemblyReferences"
     BeforeTargets="HagarGenerateCode"
-    Inputs="$(Hagar_CodeGenInputs)"
+    Inputs="@(Hagar_CodeGenInputs)"
     Outputs="$(Hagar_CodeGenInputCache)">
 
     <Hash ItemsToHash="@(Hagar_CodeGenInputs)">


### PR DESCRIPTION
My team has seen our project incremental builds break recently, and it was narrowed down the the proliferation of Hagar's codegen in the solution. It appears that the target for checking the cache is not configured to correctly take compilation inputs.

![image](https://user-images.githubusercontent.com/8509767/130305260-ae706051-59bf-4c45-9e96-f3cf7e306e66.png)

I simply changed the input propery reference to a list reference, and rebuilt a couple of times. I now see the cache file on disk, proper incremental builds, and binlog shows the inputs as expected

![image](https://user-images.githubusercontent.com/8509767/130305296-813e3bc1-f9eb-48f8-9056-62fa46478cae.png)

This would resolve #189 