### PR TITLE
Upgrade from .NET 5 to .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.x'
+        dotnet-version: '6.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.x'
+        dotnet-version: '6.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
-    - name: Setup .NET 5.0
+    - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.x'
+        dotnet-version: '6.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
     - name: Install dependencies

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Reuben Bond</Authors>
     <Product>Hagar</Product>
-    <VersionPrefix>0.6.12</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Copyright>Copyright © Reuben Bond 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ReubenBond/Hagar</PackageProjectUrl>

--- a/src/Hagar.CodeGenerator.MSBuild/Hagar.CodeGenerator.MSBuild.csproj
+++ b/src/Hagar.CodeGenerator.MSBuild/Hagar.CodeGenerator.MSBuild.csproj
@@ -80,11 +80,7 @@
     but before NuGet generates a nuspec. See https://github.com/NuGet/Home/issues/4704.
    -->
     <ItemGroup>
-      <PublishedFiles Include="$(PublishRoot)**/*" Exclude="$(PublishRoot)**/$(AssemblyName).*;$(PublishRoot)*/refs/**/*" />
-      <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).Tasks.dll" />
-      <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).Tasks.pdb" />
-      <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).deps.json" />
-      <PublishedFiles Include="$(PublishRoot)**/$(AssemblyName).*.config" />
+      <PublishedFiles Include="$(PublishRoot)**/*" Exclude="$(PublishRoot)*/refs/**/*" />
       <_PackageFiles Include="@(PublishedFiles)">
         <PackagePath>tasks/$(RecursiveDir)</PackagePath>
         <Visible>false</Visible>

--- a/src/Hagar.CodeGenerator.MSBuild/Hagar.CodeGenerator.MSBuild.csproj
+++ b/src/Hagar.CodeGenerator.MSBuild/Hagar.CodeGenerator.MSBuild.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <PackageDescription>Code generator for projects using Hagar with MSBuild</PackageDescription>
     <OutputType>Exe</OutputType>
@@ -15,7 +15,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PublishRoot>bin\$(Configuration)\publish\</PublishRoot>
-    <PublishDir>$(PublishRoot)$(TargetFramework)</PublishDir>
+    <PublishDir>$(PublishRoot)</PublishDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hagar.CodeGenerator.MSBuild/build/Hagar.CodeGenerator.MSBuild.targets
+++ b/src/Hagar.CodeGenerator.MSBuild/build/Hagar.CodeGenerator.MSBuild.targets
@@ -13,7 +13,7 @@
     <!-- Specify the assembly containing the MSBuild tasks. -->
     <Hagar_MSBuildIsCore Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(OS)' != 'Windows_NT'">true</Hagar_MSBuildIsCore>
     <Hagar_TaskAssembly Condition=" '$(HagarCodeGenTaskAssembly)' != '' ">$(HagarCodeGenTaskAssembly)</Hagar_TaskAssembly>
-    <Hagar_TaskAssembly Condition=" '$(Hagar_TaskAssembly)' == '' and '$(Hagar_MSBuildIsCore)' == 'true'">$(MSBuildThisFileDirectory)..\tasks\net5.0\Hagar.CodeGenerator.MSBuild.Tasks.dll</Hagar_TaskAssembly>
+    <Hagar_TaskAssembly Condition=" '$(Hagar_TaskAssembly)' == '' and '$(Hagar_MSBuildIsCore)' == 'true'">$(MSBuildThisFileDirectory)..\tasks\Hagar.CodeGenerator.MSBuild.Tasks.dll</Hagar_TaskAssembly>
 
     <!-- When the MSBuild host is full-framework, we defer to PATH for dotnet -->
     <Hagar_DotNetHost Condition="'$(DotNetFromPath)' == 'true'">dotnet</Hagar_DotNetHost>

--- a/src/Hagar.CodeGenerator.MSBuild/build/Hagar.CodeGenerator.MSBuild.targets
+++ b/src/Hagar.CodeGenerator.MSBuild/build/Hagar.CodeGenerator.MSBuild.targets
@@ -22,7 +22,7 @@
 
     <!-- Specify the assembly containing the code generator. -->
     <Hagar_GeneratorAssembly Condition="'$(HagarCodeGenCoreAssembly)' != ''">$(HagarCodeGenCoreAssembly)</Hagar_GeneratorAssembly>
-    <Hagar_GeneratorAssembly Condition="'$(Hagar_GeneratorAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\net5.0\Hagar.CodeGenerator.MSBuild.dll</Hagar_GeneratorAssembly>
+    <Hagar_GeneratorAssembly Condition="'$(Hagar_GeneratorAssembly)' == ''">$(MSBuildThisFileDirectory)..\tasks\Hagar.CodeGenerator.MSBuild.dll</Hagar_GeneratorAssembly>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Hagar.Sdk/Hagar.Sdk.csproj
+++ b/src/Hagar.Sdk/Hagar.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net48;netstandard2.0</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeSymbols>false</IncludeSymbols>

--- a/src/Hagar/Codecs/WellKnownStringComparerCodec.cs
+++ b/src/Hagar/Codecs/WellKnownStringComparerCodec.cs
@@ -2,6 +2,7 @@
 using Hagar.Serializers;
 using Hagar.Utilities;
 using Hagar.WireProtocol;
+using Microsoft.VisualBasic;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -13,12 +14,22 @@ namespace Hagar.Codecs
     public sealed class WellKnownStringComparerCodec : IGeneralizedCodec
     {
         private static readonly Type CodecType = typeof(WellKnownStringComparerCodec);
+
         private readonly StringComparer _ordinalComparer;
         private readonly StringComparer _ordinalIgnoreCaseComparer;
         private readonly EqualityComparer<string> _defaultEqualityComparer;
+        private readonly StringComparer _invariantComparer;
+        private readonly StringComparer _invariantIgnoreCaseComparer;
+        private readonly StringComparer _currentCultureComparer;
+        private readonly StringComparer _currentCultureIgnoreCaseComparer;
+
         private readonly Type _ordinalType;
         private readonly Type _ordinalIgnoreCaseType;
         private readonly Type _defaultEqualityType;
+        private readonly Type _invariantType;
+        private readonly Type _invariantIgnoreCaseType;
+        private readonly Type _currentCultureType;
+        private readonly Type _currentCultureIgnoreCaseType;
 
         public WellKnownStringComparerCodec()
         {
@@ -26,36 +37,57 @@ namespace Hagar.Codecs
             _ordinalIgnoreCaseComparer = StringComparer.OrdinalIgnoreCase;
             _defaultEqualityComparer = EqualityComparer<string>.Default;
 
+            _invariantComparer = StringComparer.InvariantCulture;
+            _invariantIgnoreCaseComparer = StringComparer.InvariantCultureIgnoreCase;
+            _currentCultureComparer = StringComparer.CurrentCulture;
+            _currentCultureIgnoreCaseComparer = StringComparer.CurrentCultureIgnoreCase;
+
             _ordinalType = _ordinalComparer.GetType();
             _ordinalIgnoreCaseType = _ordinalIgnoreCaseComparer.GetType();
             _defaultEqualityType = _defaultEqualityComparer.GetType();
+
+            _invariantType = _invariantComparer.GetType();
+            _invariantIgnoreCaseType = _invariantIgnoreCaseComparer.GetType();
+            _currentCultureType = _currentCultureComparer.GetType();
+            _currentCultureIgnoreCaseType = _currentCultureIgnoreCaseComparer.GetType();
         }
 
-        public bool IsSupportedType(Type type) => CodecType == type || _defaultEqualityType == type || _ordinalType == type || _ordinalIgnoreCaseType == type;
+        public bool IsSupportedType(Type type) => CodecType == type
+            || _defaultEqualityType == type
+            || _ordinalType == type
+            || _ordinalIgnoreCaseType == type
+            || _invariantType == type
+            || _invariantIgnoreCaseType == type
+            || _currentCultureType == type
+            || _currentCultureIgnoreCaseType == type;
 
         public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
         {
             ReferenceCodec.MarkValueField(reader.Session);
             var value = reader.ReadUInt32(field.WireType);
-            if (value == 0)
-            {
-                return null;
-            }
-            else if (value == 1)
-            {
-                return _ordinalComparer;
-            }
-            else if (value == 2)
-            {
-                return _ordinalIgnoreCaseComparer;
-            }
-            else if (value == 3)
-            {
-                return _defaultEqualityComparer;
-            }
 
-            ThrowNotSupported(field, value);
-            return null;
+            switch (value)
+            {
+                case 0:
+                    return null;
+                case 1:
+                    return _ordinalComparer;
+                case 2:
+                    return _ordinalIgnoreCaseComparer;
+                case 3:
+                    return _defaultEqualityComparer;
+                case 4:
+                    return _invariantComparer;
+                case 5:
+                    return _invariantIgnoreCaseComparer;
+                case 6: 
+                    return _currentCultureComparer;
+                case 7:
+                    return _currentCultureIgnoreCaseComparer;
+                default:
+                    ThrowNotSupported(field, value);
+                    return null;
+            }
         }
 
         public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
@@ -76,6 +108,22 @@ namespace Hagar.Codecs
             else if (_defaultEqualityComparer.Equals(value))
             {
                 encoded = 3;
+            }
+            else if (_invariantComparer.Equals(value))
+            {
+                encoded = 4;
+            }
+            else if (_invariantIgnoreCaseComparer.Equals(value))
+            {
+                encoded = 5;
+            }
+            else if (_currentCultureComparer.Equals(value))
+            {
+                encoded = 6;
+            }
+            else if (_currentCultureIgnoreCaseComparer.Equals(value))
+            {
+                encoded = 7;
             }
             else
             {

--- a/src/Hagar/Hagar.csproj
+++ b/src/Hagar/Hagar.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net48;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageDescription>Fast, flexible, and version-tolerant serializer for .NET</PackageDescription>
     <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
   </ItemGroup>
 

--- a/src/Hagar/Hosting/ReferencedAssemblyHelper.cs
+++ b/src/Hagar/Hosting/ReferencedAssemblyHelper.cs
@@ -130,7 +130,7 @@ namespace Hagar
 
                 try
                 {
-#if NET5_0
+#if NET6_0
                     var name = lib.GetRuntimeAssemblyNames(dependencyContext, System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier).FirstOrDefault();
                     if (name is null)
                     {

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/test/CallLog/CallLog.csproj
+++ b/test/CallLog/CallLog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>
 	<Hagar_AttachDebugger>false</Hagar_AttachDebugger>
 	  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/test/Hagar.UnitTests/Hagar.UnitTests.csproj
+++ b/test/Hagar.UnitTests/Hagar.UnitTests.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TargetFrameworks Condition=" '$(TestTargetFrameworks)' != '' ">$(TestTargetFrameworks)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net5.0;net48</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' and '$(TargetFrameworks)' == '' ">netcoreapp2.1;netcoreapp3.1;net6.0;net48</TargetFrameworks>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>9</LangVersion>
     <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>

--- a/test/TestRpc/TestRpc.csproj
+++ b/test/TestRpc/TestRpc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
     <HagarBuildTimeCodeGen>true</HagarBuildTimeCodeGen>


### PR DESCRIPTION
Relying on .NET 5 is causing issues for my team, so this PR upgrades everything to .NET 6.

A few things worth mentioning:
- I replaced .NET 5 references with .NET 6 entirely, since .NET 5 is EOL. Let me know if there's preference to keep .NET 5 as a target framework for multi-targetted projects.
- There was a pre-existing `#if NET6_0` in the DictionaryWithComparerCodecTests setup that includes more StringComparers. This broke most of the dictionary tests, so I added cases to the well known string comparer codec
- I bumped the package version to `0.7.0`

Let me know if anything should be changed