### PR TITLE
Improve StringComparer serialization for well-known comparers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Authors>Reuben Bond</Authors>
     <Product>Hagar</Product>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.7.1</VersionPrefix>
     <Copyright>Copyright © Reuben Bond 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ReubenBond/Hagar</PackageProjectUrl>


### PR DESCRIPTION
Port of https://github.com/dotnet/orleans/pull/7514 from Orleans.Serialization.

In addition, I've added test cases to `DictionaryWithComparerCodecTests` that pass `StringComparers` through a `BinaryFormatter` roundtrip before Hagar serialization. These roundtrips cause some `StringComparer` instances' type to change to `System.OridinalComparer`.

Without this PR's changes to `WellKnownStringComparerCodec`, the new `DictionaryWithComparerCodecTests` test cases fail with:
> Hagar.CodecNotFoundException: 'Could not find a codec for type System.OrdinalComparer.'

I may also open another PR on https://github.com/dotnet/orleans/ to include the new test cases.